### PR TITLE
Implement Ripplecast MCP server for cross-posting

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh issue view:*)",
+      "Bash(tree:*)"
+    ]
+  }
+}

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Mastodon Configuration
+# Get your access token from: Settings > Development > New Application
+MASTODON_INSTANCE_URL=https://mastodon.social
+MASTODON_ACCESS_TOKEN=your_access_token_here
+
+# Bluesky Configuration
+# Use an App Password, not your main password
+# Create at: Settings > App Passwords
+BLUESKY_HANDLE=yourhandle.bsky.social
+BLUESKY_APP_PASSWORD=xxxx-xxxx-xxxx-xxxx
+
+# Optional Settings
+RIPPLECAST_LOG_LEVEL=INFO

--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,7 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Ripplecast specific
+sync_history.json
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,2 +1,155 @@
-# ripplecast
-posts spread across platforms
+# Ripplecast
+
+An MCP (Model Context Protocol) server that enables cross-posting between Mastodon and Bluesky. Interact with it through Claude Desktop to manage your social media presence across platforms.
+
+*Like ripples spreading across water, your posts spread across platforms.*
+
+## Features
+
+- **View posts** across Mastodon and Bluesky from a single interface
+- **Find unsynced posts** - identify content that exists on one platform but not the other
+- **Cross-post with confirmation** - share content between platforms with full control
+- **Intelligent matching** - uses Claude to detect duplicate/similar posts across platforms
+
+## Installation
+
+### Prerequisites
+
+- Python 3.11 or higher
+- Claude Desktop
+- Mastodon account with API access
+- Bluesky account with App Password
+
+### Setup
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/yourusername/ripplecast.git
+   cd ripplecast
+   ```
+
+2. Create a virtual environment and install dependencies:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate  # On Windows: .venv\Scripts\activate
+   pip install -e ".[dev]"
+   ```
+
+3. Copy `.env.example` to `.env` and fill in your credentials:
+   ```bash
+   cp .env.example .env
+   ```
+
+4. Configure Claude Desktop (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+   ```json
+   {
+     "mcpServers": {
+       "ripplecast": {
+         "command": "/path/to/ripplecast/.venv/bin/python",
+         "args": ["-m", "ripplecast.server"]
+       }
+     }
+   }
+   ```
+
+## Getting Credentials
+
+### Mastodon Access Token
+
+1. Go to your Mastodon instance's Settings
+2. Navigate to **Development > New Application**
+3. Give it a name (e.g., "Ripplecast")
+4. Required scopes: `read:accounts`, `read:statuses`, `write:statuses`
+5. Copy the **Access Token** after creation
+
+### Bluesky App Password
+
+1. Go to **Settings** in Bluesky
+2. Navigate to **App Passwords**
+3. Create a new app password
+4. Copy the generated password (format: `xxxx-xxxx-xxxx-xxxx`)
+
+## Usage
+
+Once configured, restart Claude Desktop. You can then use natural language to interact:
+
+- "What posts do I have on Mastodon that aren't on Bluesky?"
+- "Show me my recent Bluesky posts"
+- "Cross-post that article I shared yesterday from Mastodon to Bluesky"
+- "Sync all my unsynced posts from the last week"
+
+## Development
+
+### Running Tests
+
+```bash
+# All tests
+pytest tests/
+
+# With coverage
+pytest tests/ --cov=ripplecast
+
+# Specific test file
+pytest tests/test_matching.py -v
+```
+
+### Code Formatting
+
+```bash
+isort src/ripplecast/
+black src/ripplecast/
+mypy src/ripplecast/
+```
+
+### Running with MCP Inspector
+
+For debugging:
+
+```bash
+npx @modelcontextprotocol/inspector python -m ripplecast.server
+```
+
+## Architecture
+
+```
+┌─────────────────────┐
+│   Claude Desktop    │
+└──────────┬──────────┘
+           │ MCP Protocol (stdio)
+           ▼
+┌─────────────────────────────────────┐
+│        Ripplecast MCP Server        │
+│  ┌────────────────────────────────┐ │
+│  │     Core Server (FastMCP)      │ │
+│  └────────────────────────────────┘ │
+│  ┌────────────────────────────────┐ │
+│  │     Platform Manager           │ │
+│  │  (plugin registry & routing)   │ │
+│  └────────────────────────────────┘ │
+│  ┌──────────┐  ┌──────────────────┐ │
+│  │ Mastodon │  │     Bluesky      │ │
+│  │  Plugin  │  │      Plugin      │ │
+│  └──────────┘  └──────────────────┘ │
+└─────────────────────────────────────┘
+```
+
+## MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `list_platforms` | List configured platforms and connection status |
+| `get_posts` | Fetch recent posts from a platform |
+| `find_unsynced_posts` | Find posts missing from other platforms |
+| `cross_post` | Cross-post a single post |
+| `bulk_cross_post` | Cross-post multiple posts (with dry-run) |
+| `get_sync_status` | Check if a specific post has been synced |
+
+## Limitations (v1)
+
+- Media attachments are not transferred during cross-posting
+- Thread/reply chains are not preserved
+- No scheduled posting
+
+## License
+
+MIT

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,63 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "ripplecast"
+version = "0.1.0"
+description = "MCP server for cross-posting between Mastodon and Bluesky"
+readme = "README.md"
+requires-python = ">=3.11"
+license = {text = "MIT"}
+authors = [
+    {name = "Shane"},
+]
+keywords = ["mcp", "mastodon", "bluesky", "cross-posting", "social-media"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: End Users/Desktop",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+dependencies = [
+    "mcp>=1.0.0",
+    "Mastodon.py>=2.0.0",
+    "atproto>=0.0.50",
+    "python-dotenv>=1.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.23.0",
+    "pytest-mock>=3.12.0",
+    "pytest-cov>=4.1.0",
+    "black>=24.0.0",
+    "isort>=5.13.0",
+    "mypy>=1.8.0",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/ripplecast"]
+
+[tool.black]
+line-length = 100
+target-version = ["py311"]
+
+[tool.isort]
+profile = "black"
+line_length = 100
+
+[tool.mypy]
+python_version = "3.11"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true
+strict = true
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+addopts = "-v"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,8 @@
+-r requirements.txt
+pytest>=8.0.0
+pytest-asyncio>=0.23.0
+pytest-mock>=3.12.0
+pytest-cov>=4.1.0
+black>=24.0.0
+isort>=5.13.0
+mypy>=1.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+mcp>=1.0.0
+Mastodon.py>=2.0.0
+atproto>=0.0.50
+python-dotenv>=1.0.0

--- a/src/ripplecast/__init__.py
+++ b/src/ripplecast/__init__.py
@@ -1,0 +1,3 @@
+"""Ripplecast - MCP server for cross-posting between Mastodon and Bluesky."""
+
+__version__ = "0.1.0"

--- a/src/ripplecast/config.py
+++ b/src/ripplecast/config.py
@@ -1,0 +1,81 @@
+"""Configuration management for Ripplecast."""
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+
+@dataclass
+class MastodonConfig:
+    """Mastodon platform configuration."""
+
+    instance_url: str
+    access_token: str
+
+    @property
+    def is_configured(self) -> bool:
+        """Check if all required fields are set."""
+        return bool(self.instance_url and self.access_token)
+
+
+@dataclass
+class BlueskyConfig:
+    """Bluesky platform configuration."""
+
+    handle: str
+    app_password: str
+
+    @property
+    def is_configured(self) -> bool:
+        """Check if all required fields are set."""
+        return bool(self.handle and self.app_password)
+
+
+@dataclass
+class Config:
+    """Main configuration container."""
+
+    mastodon: MastodonConfig
+    bluesky: BlueskyConfig
+    log_level: str = "INFO"
+
+    @classmethod
+    def from_env(cls, env_path: Path | None = None) -> "Config":
+        """Load configuration from environment variables."""
+        if env_path:
+            load_dotenv(env_path)
+        else:
+            load_dotenv()
+
+        return cls(
+            mastodon=MastodonConfig(
+                instance_url=os.getenv("MASTODON_INSTANCE_URL", ""),
+                access_token=os.getenv("MASTODON_ACCESS_TOKEN", ""),
+            ),
+            bluesky=BlueskyConfig(
+                handle=os.getenv("BLUESKY_HANDLE", ""),
+                app_password=os.getenv("BLUESKY_APP_PASSWORD", ""),
+            ),
+            log_level=os.getenv("RIPPLECAST_LOG_LEVEL", "INFO"),
+        )
+
+
+# Global config instance (lazy loaded)
+_config: Config | None = None
+
+
+def get_config() -> Config:
+    """Get the global configuration instance."""
+    global _config
+    if _config is None:
+        _config = Config.from_env()
+    return _config
+
+
+def reload_config(env_path: Path | None = None) -> Config:
+    """Reload configuration from environment."""
+    global _config
+    _config = Config.from_env(env_path)
+    return _config

--- a/src/ripplecast/matching.py
+++ b/src/ripplecast/matching.py
@@ -1,0 +1,192 @@
+"""LLM-based post matching via MCP sampling."""
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+from mcp.server.session import ServerSession
+from mcp.types import SamplingMessage, TextContent
+
+from ripplecast.models import Post, PostMatch
+
+if TYPE_CHECKING:
+    from mcp.server.fastmcp import Context
+
+logger = logging.getLogger(__name__)
+
+
+async def match_posts_with_llm(
+    posts_a: list[Post],
+    posts_b: list[Post],
+    ctx: "Context[ServerSession, Any]",
+    platform_a: str = "Platform A",
+    platform_b: str = "Platform B",
+) -> list[PostMatch]:
+    """
+    Use LLM sampling to match posts across platforms.
+
+    Args:
+        posts_a: Posts from the first platform
+        posts_b: Posts from the second platform
+        ctx: MCP context for sampling
+        platform_a: Display name for first platform
+        platform_b: Display name for second platform
+
+    Returns:
+        List of PostMatch objects for matched posts
+    """
+    if not posts_a or not posts_b:
+        return []
+
+    # Format posts for comparison (limit text to avoid token explosion)
+    posts_a_formatted = "\n".join(
+        [
+            f"[A{i}] ({p.created_at.strftime('%Y-%m-%d %H:%M')}): {p.text[:200]}"
+            for i, p in enumerate(posts_a)
+        ]
+    )
+
+    posts_b_formatted = "\n".join(
+        [
+            f"[B{i}] ({p.created_at.strftime('%Y-%m-%d %H:%M')}): {p.text[:200]}"
+            for i, p in enumerate(posts_b)
+        ]
+    )
+
+    prompt = f"""Compare these two lists of social media posts and identify which posts are the same content (cross-posted).
+
+Posts from {platform_a}:
+{posts_a_formatted}
+
+Posts from {platform_b}:
+{posts_b_formatted}
+
+For each match found, respond with a JSON array of objects:
+[
+  {{"a_index": 0, "b_index": 2, "confidence": 0.95, "reason": "identical text"}},
+  ...
+]
+
+Only include matches with confidence >= 0.7. Consider:
+- Exact or near-exact text matches
+- Same content with minor edits (typos, length adjustments)
+- Same links or media references
+- Posted within similar timeframes
+
+If no matches found, return an empty array: []
+
+Respond ONLY with the JSON array, no other text."""
+
+    try:
+        result = await ctx.session.create_message(
+            messages=[
+                SamplingMessage(
+                    role="user",
+                    content=TextContent(type="text", text=prompt),
+                )
+            ],
+            max_tokens=1000,
+        )
+
+        # Parse the JSON response
+        if hasattr(result, "content") and hasattr(result.content, "text"):
+            response_text = result.content.text.strip()
+
+            # Handle potential markdown code blocks
+            if response_text.startswith("```"):
+                lines = response_text.split("\n")
+                response_text = "\n".join(lines[1:-1])
+
+            matches_data = json.loads(response_text)
+
+            matches = []
+            for m in matches_data:
+                a_idx = m.get("a_index")
+                b_idx = m.get("b_index")
+                confidence = m.get("confidence", 0.0)
+                reason = m.get("reason", "")
+
+                if a_idx is not None and b_idx is not None:
+                    if 0 <= a_idx < len(posts_a) and 0 <= b_idx < len(posts_b):
+                        matches.append(
+                            PostMatch(
+                                post_a_id=posts_a[a_idx].id,
+                                post_b_id=posts_b[b_idx].id,
+                                confidence=confidence,
+                                reason=reason,
+                            )
+                        )
+
+            return matches
+
+    except json.JSONDecodeError as e:
+        logger.warning(f"Failed to parse LLM response as JSON: {e}")
+    except Exception as e:
+        logger.error(f"Error during post matching: {e}")
+
+    return []
+
+
+def find_unmatched_posts(
+    posts: list[Post],
+    matches: list[PostMatch],
+    platform: str,
+) -> list[Post]:
+    """
+    Find posts that don't have any matches.
+
+    Args:
+        posts: List of posts from a platform
+        matches: List of matches found
+        platform: Which platform these posts are from ("a" or "b")
+
+    Returns:
+        Posts that have no matches
+    """
+    # Get all matched post IDs for this platform
+    if platform == "a":
+        matched_ids = {m.post_a_id for m in matches}
+    else:
+        matched_ids = {m.post_b_id for m in matches}
+
+    # Return posts that aren't matched
+    return [p for p in posts if p.id not in matched_ids]
+
+
+def build_sync_summary(
+    mastodon_posts: list[Post],
+    bluesky_posts: list[Post],
+    matches: list[PostMatch],
+) -> dict[str, Any]:
+    """
+    Build a summary of sync status between platforms.
+
+    Returns a dict with:
+    - mastodon_only: Posts only on Mastodon
+    - bluesky_only: Posts only on Bluesky
+    - synced: Posts that exist on both
+    - summary: Count summary
+    """
+    mastodon_only = find_unmatched_posts(mastodon_posts, matches, "a")
+    bluesky_only = find_unmatched_posts(bluesky_posts, matches, "b")
+
+    return {
+        "mastodon_only": [p.to_dict() for p in mastodon_only],
+        "bluesky_only": [p.to_dict() for p in bluesky_only],
+        "synced": [
+            {
+                "mastodon_id": m.post_a_id,
+                "bluesky_id": m.post_b_id,
+                "confidence": m.confidence,
+                "reason": m.reason,
+            }
+            for m in matches
+        ],
+        "summary": {
+            "mastodon_only_count": len(mastodon_only),
+            "bluesky_only_count": len(bluesky_only),
+            "synced_count": len(matches),
+            "total_mastodon": len(mastodon_posts),
+            "total_bluesky": len(bluesky_posts),
+        },
+    }

--- a/src/ripplecast/models.py
+++ b/src/ripplecast/models.py
@@ -1,0 +1,136 @@
+"""Shared data models for Ripplecast."""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+
+@dataclass
+class MediaAttachment:
+    """Represents a media attachment on a post."""
+
+    url: str
+    media_type: str  # "image", "video", "audio", "gif"
+    alt_text: str | None = None
+    mime_type: str | None = None
+
+
+@dataclass
+class Post:
+    """Normalized representation of a social media post across platforms."""
+
+    id: str
+    platform: str  # "mastodon" or "bluesky"
+    text: str
+    created_at: datetime
+    url: str
+
+    # Optional fields
+    media_attachments: list[MediaAttachment] = field(default_factory=list)
+    reply_to_id: str | None = None
+    is_repost: bool = False
+    original_post_id: str | None = None
+    language: str | None = None
+
+    # Platform-specific raw data
+    raw_data: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to a JSON-serializable dictionary."""
+        return {
+            "id": self.id,
+            "platform": self.platform,
+            "text": self.text,
+            "created_at": self.created_at.isoformat(),
+            "url": self.url,
+            "has_media": len(self.media_attachments) > 0,
+            "media_count": len(self.media_attachments),
+            "is_reply": self.reply_to_id is not None,
+            "is_repost": self.is_repost,
+            "language": self.language,
+        }
+
+
+@dataclass
+class SimilarPost:
+    """A post that potentially matches another post."""
+
+    post: Post
+    similarity_score: float  # 0.0 to 1.0
+    match_reason: str  # "exact", "fuzzy", "partial"
+
+
+@dataclass
+class PostComparison:
+    """Result of comparing posts across platforms."""
+
+    post: Post
+    exists_on: list[str]
+    missing_from: list[str]
+    similar_posts: list[SimilarPost] = field(default_factory=list)
+
+
+@dataclass
+class PostMatch:
+    """Represents a match between two posts on different platforms."""
+
+    post_a_id: str
+    post_b_id: str
+    confidence: float
+    reason: str
+
+
+# Custom exceptions
+
+
+class RipplecastError(Exception):
+    """Base exception for Ripplecast."""
+
+    pass
+
+
+class AuthenticationError(RipplecastError):
+    """Failed to authenticate with platform."""
+
+    pass
+
+
+class PlatformNotFoundError(RipplecastError):
+    """Referenced platform is not configured."""
+
+    pass
+
+
+class PostNotFoundError(RipplecastError):
+    """Post ID not found on platform."""
+
+    pass
+
+
+class PostTooLongError(RipplecastError):
+    """Post exceeds target platform character limit."""
+
+    def __init__(self, text: str, limit: int, platform: str):
+        self.text = text
+        self.limit = limit
+        self.platform = platform
+        self.length = len(text)
+        super().__init__(f"Post is {self.length} chars but {platform} allows max {limit}")
+
+
+class RateLimitError(RipplecastError):
+    """Hit API rate limit."""
+
+    def __init__(self, platform: str, retry_after: int | None = None):
+        self.platform = platform
+        self.retry_after = retry_after
+        msg = f"Rate limited by {platform}"
+        if retry_after:
+            msg += f", retry after {retry_after} seconds"
+        super().__init__(msg)
+
+
+class MediaNotSupportedError(RipplecastError):
+    """Media type not supported for cross-posting."""
+
+    pass

--- a/src/ripplecast/platform_manager.py
+++ b/src/ripplecast/platform_manager.py
@@ -1,0 +1,169 @@
+"""Platform plugin registry and routing."""
+
+import logging
+from typing import Any
+
+from ripplecast.config import get_config
+from ripplecast.models import PlatformNotFoundError, Post
+from ripplecast.platforms.base import PlatformPlugin
+from ripplecast.platforms.bluesky import BlueskyPlugin
+from ripplecast.platforms.mastodon import MastodonPlugin
+
+logger = logging.getLogger(__name__)
+
+
+class PlatformManager:
+    """Manages platform plugins and routes requests."""
+
+    def __init__(self) -> None:
+        self._platforms: dict[str, PlatformPlugin] = {}
+        self._initialized = False
+
+    async def initialize(self) -> None:
+        """Initialize and authenticate all configured platforms."""
+        if self._initialized:
+            return
+
+        config = get_config()
+
+        # Register Mastodon
+        if config.mastodon.is_configured:
+            mastodon = MastodonPlugin(config.mastodon)
+            self._platforms["mastodon"] = mastodon
+            logger.info("Mastodon plugin registered")
+
+        # Register Bluesky
+        if config.bluesky.is_configured:
+            bluesky = BlueskyPlugin(config.bluesky)
+            self._platforms["bluesky"] = bluesky
+            logger.info("Bluesky plugin registered")
+
+        # Authenticate all platforms
+        for name, plugin in self._platforms.items():
+            try:
+                success = await plugin.authenticate()
+                if success:
+                    logger.info(f"Successfully authenticated with {name}")
+                else:
+                    logger.warning(f"Failed to authenticate with {name}")
+            except Exception as e:
+                logger.error(f"Error authenticating with {name}: {e}")
+
+        self._initialized = True
+
+    def get_platform(self, name: str) -> PlatformPlugin:
+        """Get a platform plugin by name."""
+        if name not in self._platforms:
+            raise PlatformNotFoundError(f"Platform '{name}' is not configured")
+        return self._platforms[name]
+
+    def get_all_platforms(self) -> dict[str, PlatformPlugin]:
+        """Get all registered platform plugins."""
+        return self._platforms.copy()
+
+    def list_platforms(self) -> list[dict[str, Any]]:
+        """List all platforms and their connection status."""
+        platforms = []
+        for name, plugin in self._platforms.items():
+            platforms.append(
+                {
+                    "name": name,
+                    "display_name": plugin.display_name,
+                    "connected": plugin.connected,
+                    "max_post_length": plugin.max_post_length,
+                }
+            )
+        return platforms
+
+    async def get_platform_status(self) -> list[dict[str, Any]]:
+        """Get detailed status for all platforms including user info."""
+        statuses = []
+        for name, plugin in self._platforms.items():
+            status: dict[str, Any] = {
+                "name": name,
+                "display_name": plugin.display_name,
+                "connected": plugin.connected,
+            }
+
+            if plugin.connected:
+                try:
+                    user = await plugin.get_current_user()
+                    status["username"] = user.get("username")
+                    status["url"] = user.get("url")
+                    if "instance_url" in user:
+                        status["instance_url"] = user["instance_url"]
+                except Exception as e:
+                    status["error"] = str(e)
+            else:
+                status["error"] = "Not authenticated"
+
+            statuses.append(status)
+
+        return statuses
+
+    async def get_posts(
+        self,
+        platform: str,
+        limit: int = 20,
+        exclude_replies: bool = True,
+        exclude_reposts: bool = True,
+    ) -> list[Post]:
+        """Get posts from a specific platform."""
+        plugin = self.get_platform(platform)
+        return await plugin.get_posts(
+            limit=limit,
+            exclude_replies=exclude_replies,
+            exclude_reposts=exclude_reposts,
+        )
+
+    async def get_all_posts(
+        self,
+        limit: int = 20,
+        exclude_replies: bool = True,
+        exclude_reposts: bool = True,
+    ) -> dict[str, list[Post]]:
+        """Get posts from all connected platforms."""
+        result: dict[str, list[Post]] = {}
+
+        for name, plugin in self._platforms.items():
+            if plugin.connected:
+                try:
+                    posts = await plugin.get_posts(
+                        limit=limit,
+                        exclude_replies=exclude_replies,
+                        exclude_reposts=exclude_reposts,
+                    )
+                    result[name] = posts
+                except Exception as e:
+                    logger.error(f"Error fetching posts from {name}: {e}")
+                    result[name] = []
+
+        return result
+
+    async def create_post(
+        self,
+        platform: str,
+        text: str,
+        language: str | None = None,
+    ) -> Post:
+        """Create a post on a specific platform."""
+        plugin = self.get_platform(platform)
+        return await plugin.create_post(text=text, language=language)
+
+    async def get_post_by_id(self, platform: str, post_id: str) -> Post | None:
+        """Get a specific post by ID from a platform."""
+        plugin = self.get_platform(platform)
+        return await plugin.get_post_by_id(post_id)
+
+
+# Global platform manager instance (lazy initialized)
+_manager: PlatformManager | None = None
+
+
+async def get_platform_manager() -> PlatformManager:
+    """Get the global platform manager instance."""
+    global _manager
+    if _manager is None:
+        _manager = PlatformManager()
+        await _manager.initialize()
+    return _manager

--- a/src/ripplecast/platforms/__init__.py
+++ b/src/ripplecast/platforms/__init__.py
@@ -1,0 +1,7 @@
+"""Platform plugins for Ripplecast."""
+
+from ripplecast.platforms.base import PlatformPlugin
+from ripplecast.platforms.bluesky import BlueskyPlugin
+from ripplecast.platforms.mastodon import MastodonPlugin
+
+__all__ = ["PlatformPlugin", "MastodonPlugin", "BlueskyPlugin"]

--- a/src/ripplecast/platforms/base.py
+++ b/src/ripplecast/platforms/base.py
@@ -1,0 +1,126 @@
+"""Abstract base class for platform plugins."""
+
+from abc import ABC, abstractmethod
+
+from ripplecast.models import MediaAttachment, Post
+
+
+class PlatformPlugin(ABC):
+    """Base class for social media platform plugins."""
+
+    @property
+    @abstractmethod
+    def platform_name(self) -> str:
+        """Unique identifier for this platform (e.g., 'mastodon', 'bluesky')."""
+        pass
+
+    @property
+    @abstractmethod
+    def display_name(self) -> str:
+        """Human-readable name (e.g., 'Mastodon', 'Bluesky')."""
+        pass
+
+    @property
+    @abstractmethod
+    def max_post_length(self) -> int:
+        """Maximum characters allowed in a post."""
+        pass
+
+    @property
+    @abstractmethod
+    def connected(self) -> bool:
+        """Whether the plugin is currently authenticated."""
+        pass
+
+    @abstractmethod
+    async def authenticate(self) -> bool:
+        """
+        Authenticate with the platform using configured credentials.
+        Returns True if successful, False otherwise.
+        """
+        pass
+
+    @abstractmethod
+    async def get_current_user(self) -> dict:
+        """
+        Get the authenticated user's profile information.
+        Returns dict with at least: id, username, display_name, url
+        """
+        pass
+
+    @abstractmethod
+    async def get_posts(
+        self,
+        limit: int = 20,
+        since_id: str | None = None,
+        max_id: str | None = None,
+        exclude_replies: bool = True,
+        exclude_reposts: bool = True,
+    ) -> list[Post]:
+        """
+        Fetch recent posts from the authenticated user's timeline.
+
+        Args:
+            limit: Maximum number of posts to return
+            since_id: Only return posts newer than this ID
+            max_id: Only return posts older than this ID
+            exclude_replies: Filter out reply posts
+            exclude_reposts: Filter out reposts/boosts
+
+        Returns:
+            List of Post objects, newest first
+        """
+        pass
+
+    @abstractmethod
+    async def create_post(
+        self,
+        text: str,
+        media: list[MediaAttachment] | None = None,
+        reply_to_id: str | None = None,
+        language: str | None = None,
+    ) -> Post:
+        """
+        Create a new post on this platform.
+
+        Args:
+            text: The post content
+            media: Optional media attachments
+            reply_to_id: ID of post to reply to (if reply)
+            language: ISO language code
+
+        Returns:
+            The created Post object
+
+        Raises:
+            PostTooLongError: If text exceeds max_post_length
+            MediaUploadError: If media upload fails
+            AuthenticationError: If not authenticated
+        """
+        pass
+
+    @abstractmethod
+    async def delete_post(self, post_id: str) -> bool:
+        """
+        Delete a post by ID.
+        Returns True if successful.
+        """
+        pass
+
+    @abstractmethod
+    async def get_post_by_id(self, post_id: str) -> Post | None:
+        """
+        Fetch a specific post by its ID.
+        Returns None if not found.
+        """
+        pass
+
+    def validate_post_content(self, text: str) -> tuple[bool, str | None]:
+        """
+        Validate post content before creating.
+        Returns (is_valid, error_message).
+        Default implementation checks length.
+        """
+        if len(text) > self.max_post_length:
+            return False, f"Post exceeds {self.max_post_length} characters (got {len(text)})"
+        return True, None

--- a/src/ripplecast/platforms/bluesky.py
+++ b/src/ripplecast/platforms/bluesky.py
@@ -1,0 +1,263 @@
+"""Bluesky platform plugin."""
+
+import logging
+from datetime import datetime
+from typing import Any
+
+from atproto import Client
+from atproto.exceptions import AtProtocolError, UnauthorizedError
+
+from ripplecast.config import BlueskyConfig
+from ripplecast.models import (
+    AuthenticationError,
+    MediaAttachment,
+    Post,
+    PostNotFoundError,
+    PostTooLongError,
+    RateLimitError,
+)
+from ripplecast.platforms.base import PlatformPlugin
+
+logger = logging.getLogger(__name__)
+
+
+class BlueskyPlugin(PlatformPlugin):
+    """Bluesky platform implementation."""
+
+    def __init__(self, config: BlueskyConfig):
+        self._config = config
+        self._client: Client | None = None
+        self._connected = False
+
+    @property
+    def platform_name(self) -> str:
+        return "bluesky"
+
+    @property
+    def display_name(self) -> str:
+        return "Bluesky"
+
+    @property
+    def max_post_length(self) -> int:
+        return 300
+
+    @property
+    def connected(self) -> bool:
+        return self._connected
+
+    async def authenticate(self) -> bool:
+        """Authenticate with Bluesky using the configured app password."""
+        if not self._config.is_configured:
+            logger.warning("Bluesky credentials not configured")
+            return False
+
+        try:
+            self._client = Client()
+            self._client.login(self._config.handle, self._config.app_password)
+            self._connected = True
+            logger.info(f"Authenticated as {self._config.handle}")
+            return True
+        except UnauthorizedError:
+            logger.error("Bluesky authentication failed: Invalid credentials")
+            self._connected = False
+            return False
+        except Exception as e:
+            logger.error(f"Bluesky authentication failed: {e}")
+            self._connected = False
+            return False
+
+    async def get_current_user(self) -> dict[str, Any]:
+        """Get the authenticated user's profile information."""
+        if not self._connected or not self._client:
+            raise AuthenticationError("Not authenticated with Bluesky")
+
+        profile = self._client.get_profile(actor=self._client.me.did)
+
+        return {
+            "id": self._client.me.did,
+            "username": profile.handle,
+            "display_name": profile.display_name or profile.handle,
+            "url": f"https://bsky.app/profile/{profile.handle}",
+        }
+
+    async def get_posts(
+        self,
+        limit: int = 20,
+        since_id: str | None = None,
+        max_id: str | None = None,
+        exclude_replies: bool = True,
+        exclude_reposts: bool = True,
+    ) -> list[Post]:
+        """Fetch recent posts from the authenticated user."""
+        if not self._connected or not self._client:
+            raise AuthenticationError("Not authenticated with Bluesky")
+
+        try:
+            response = self._client.get_author_feed(
+                actor=self._client.me.did,
+                limit=min(limit, 100),
+                cursor=max_id,
+            )
+
+            posts = []
+            for feed_item in response.feed:
+                post = feed_item.post
+                reason = feed_item.reason
+
+                # Check if this is a repost
+                is_repost = reason is not None and hasattr(reason, "py_type")
+
+                # Skip reposts if requested
+                if exclude_reposts and is_repost:
+                    continue
+
+                # Skip replies if requested
+                if exclude_replies and post.record.reply is not None:
+                    continue
+
+                # Skip if we've passed the since_id
+                if since_id and post.uri == since_id:
+                    break
+
+                converted_post = self._feed_post_to_post(post, is_repost)
+                posts.append(converted_post)
+
+            return posts
+
+        except AtProtocolError as e:
+            if "rate" in str(e).lower():
+                raise RateLimitError("bluesky")
+            raise
+
+    async def create_post(
+        self,
+        text: str,
+        media: list[MediaAttachment] | None = None,
+        reply_to_id: str | None = None,
+        language: str | None = None,
+    ) -> Post:
+        """Create a new post on Bluesky."""
+        if not self._connected or not self._client:
+            raise AuthenticationError("Not authenticated with Bluesky")
+
+        # Validate content
+        is_valid, error = self.validate_post_content(text)
+        if not is_valid:
+            raise PostTooLongError(text, self.max_post_length, "bluesky")
+
+        try:
+            # Note: Media upload and replies not implemented in v1
+            response = self._client.send_post(text=text)
+
+            # Fetch the created post to return full details
+            # The response contains the URI and CID of the new post
+            return Post(
+                id=response.uri,
+                platform="bluesky",
+                text=text,
+                created_at=datetime.now(),
+                url=self._uri_to_url(response.uri),
+                raw_data={"uri": response.uri, "cid": response.cid},
+            )
+
+        except AtProtocolError as e:
+            if "rate" in str(e).lower():
+                raise RateLimitError("bluesky")
+            raise
+
+    async def delete_post(self, post_id: str) -> bool:
+        """Delete a post by ID (URI)."""
+        if not self._connected or not self._client:
+            raise AuthenticationError("Not authenticated with Bluesky")
+
+        try:
+            self._client.delete_post(post_id)
+            return True
+        except AtProtocolError:
+            return False
+
+    async def get_post_by_id(self, post_id: str) -> Post | None:
+        """Fetch a specific post by ID (URI)."""
+        if not self._connected or not self._client:
+            raise AuthenticationError("Not authenticated with Bluesky")
+
+        try:
+            # Parse the URI to get repo and rkey
+            # URI format: at://did:plc:xxx/app.bsky.feed.post/xxx
+            parts = post_id.replace("at://", "").split("/")
+            if len(parts) < 3:
+                raise PostNotFoundError(f"Invalid post URI: {post_id}")
+
+            repo = parts[0]
+            rkey = parts[2]
+
+            response = self._client.get_post(rkey, repo)
+
+            return Post(
+                id=response.uri,
+                platform="bluesky",
+                text=response.value.text,
+                created_at=datetime.fromisoformat(
+                    response.value.created_at.replace("Z", "+00:00")
+                ),
+                url=self._uri_to_url(response.uri),
+                raw_data={"uri": response.uri, "cid": response.cid},
+            )
+
+        except AtProtocolError:
+            raise PostNotFoundError(f"Post {post_id} not found on Bluesky")
+
+    def _feed_post_to_post(self, post: Any, is_repost: bool = False) -> Post:
+        """Convert a Bluesky feed post to our Post model."""
+        # Parse media attachments if present
+        media_attachments = []
+        if hasattr(post.record, "embed") and post.record.embed:
+            embed = post.record.embed
+            if hasattr(embed, "images"):
+                for img in embed.images:
+                    media_attachments.append(
+                        MediaAttachment(
+                            url=img.fullsize if hasattr(img, "fullsize") else "",
+                            media_type="image",
+                            alt_text=img.alt if hasattr(img, "alt") else None,
+                        )
+                    )
+
+        # Parse created_at
+        created_at = post.record.created_at
+        if isinstance(created_at, str):
+            created_at = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+
+        # Check if reply
+        reply_to_id = None
+        if hasattr(post.record, "reply") and post.record.reply:
+            reply_to_id = post.record.reply.parent.uri
+
+        return Post(
+            id=post.uri,
+            platform="bluesky",
+            text=post.record.text,
+            created_at=created_at,
+            url=self._uri_to_url(post.uri),
+            media_attachments=media_attachments,
+            reply_to_id=reply_to_id,
+            is_repost=is_repost,
+            language=post.record.langs[0] if hasattr(post.record, "langs") and post.record.langs else None,
+            raw_data={"uri": post.uri, "cid": post.cid},
+        )
+
+    def _uri_to_url(self, uri: str) -> str:
+        """Convert an AT Protocol URI to a bsky.app URL."""
+        # URI format: at://did:plc:xxx/app.bsky.feed.post/rkey
+        # URL format: https://bsky.app/profile/handle/post/rkey
+        try:
+            parts = uri.replace("at://", "").split("/")
+            did = parts[0]
+            rkey = parts[2] if len(parts) > 2 else ""
+
+            # Get handle from DID (we might need to resolve this)
+            handle = self._config.handle
+
+            return f"https://bsky.app/profile/{handle}/post/{rkey}"
+        except Exception:
+            return uri

--- a/src/ripplecast/platforms/mastodon.py
+++ b/src/ripplecast/platforms/mastodon.py
@@ -1,0 +1,226 @@
+"""Mastodon platform plugin."""
+
+import logging
+from datetime import datetime
+from typing import Any
+
+from mastodon import Mastodon, MastodonAPIError, MastodonUnauthorizedError
+
+from ripplecast.config import MastodonConfig
+from ripplecast.models import (
+    AuthenticationError,
+    MediaAttachment,
+    Post,
+    PostNotFoundError,
+    PostTooLongError,
+    RateLimitError,
+)
+from ripplecast.platforms.base import PlatformPlugin
+
+logger = logging.getLogger(__name__)
+
+
+class MastodonPlugin(PlatformPlugin):
+    """Mastodon platform implementation."""
+
+    def __init__(self, config: MastodonConfig):
+        self._config = config
+        self._client: Mastodon | None = None
+        self._user: dict[str, Any] | None = None
+        self._connected = False
+        self._instance_info: dict[str, Any] | None = None
+
+    @property
+    def platform_name(self) -> str:
+        return "mastodon"
+
+    @property
+    def display_name(self) -> str:
+        return "Mastodon"
+
+    @property
+    def max_post_length(self) -> int:
+        # Default to 500, but can be overridden by instance config
+        if self._instance_info:
+            return self._instance_info.get("max_toot_chars", 500)
+        return 500
+
+    @property
+    def connected(self) -> bool:
+        return self._connected
+
+    async def authenticate(self) -> bool:
+        """Authenticate with Mastodon using the configured access token."""
+        if not self._config.is_configured:
+            logger.warning("Mastodon credentials not configured")
+            return False
+
+        try:
+            self._client = Mastodon(
+                access_token=self._config.access_token,
+                api_base_url=self._config.instance_url,
+            )
+            # Verify credentials by fetching current user
+            self._user = self._client.account_verify_credentials()
+            self._instance_info = self._client.instance()
+            self._connected = True
+            logger.info(f"Authenticated as @{self._user['username']}@{self._config.instance_url}")
+            return True
+        except MastodonUnauthorizedError:
+            logger.error("Mastodon authentication failed: Invalid access token")
+            self._connected = False
+            return False
+        except Exception as e:
+            logger.error(f"Mastodon authentication failed: {e}")
+            self._connected = False
+            return False
+
+    async def get_current_user(self) -> dict[str, Any]:
+        """Get the authenticated user's profile information."""
+        if not self._connected or not self._user:
+            raise AuthenticationError("Not authenticated with Mastodon")
+
+        return {
+            "id": self._user["id"],
+            "username": f"@{self._user['username']}@{self._config.instance_url.replace('https://', '')}",
+            "display_name": self._user.get("display_name", self._user["username"]),
+            "url": self._user["url"],
+            "instance_url": self._config.instance_url,
+        }
+
+    async def get_posts(
+        self,
+        limit: int = 20,
+        since_id: str | None = None,
+        max_id: str | None = None,
+        exclude_replies: bool = True,
+        exclude_reposts: bool = True,
+    ) -> list[Post]:
+        """Fetch recent posts from the authenticated user."""
+        if not self._connected or not self._client or not self._user:
+            raise AuthenticationError("Not authenticated with Mastodon")
+
+        try:
+            statuses = self._client.account_statuses(
+                self._user["id"],
+                limit=min(limit, 100),  # Mastodon max is 40 per request typically
+                since_id=since_id,
+                max_id=max_id,
+                exclude_replies=exclude_replies,
+                exclude_reblogs=exclude_reposts,
+            )
+
+            posts = []
+            for status in statuses:
+                post = self._status_to_post(status)
+                posts.append(post)
+
+            return posts
+
+        except MastodonAPIError as e:
+            if "rate limit" in str(e).lower():
+                raise RateLimitError("mastodon")
+            raise
+
+    async def create_post(
+        self,
+        text: str,
+        media: list[MediaAttachment] | None = None,
+        reply_to_id: str | None = None,
+        language: str | None = None,
+    ) -> Post:
+        """Create a new post on Mastodon."""
+        if not self._connected or not self._client:
+            raise AuthenticationError("Not authenticated with Mastodon")
+
+        # Validate content
+        is_valid, error = self.validate_post_content(text)
+        if not is_valid:
+            raise PostTooLongError(text, self.max_post_length, "mastodon")
+
+        try:
+            # Note: Media upload not implemented in v1
+            status = self._client.status_post(
+                status=text,
+                in_reply_to_id=reply_to_id,
+                language=language,
+            )
+
+            return self._status_to_post(status)
+
+        except MastodonAPIError as e:
+            if "rate limit" in str(e).lower():
+                raise RateLimitError("mastodon")
+            raise
+
+    async def delete_post(self, post_id: str) -> bool:
+        """Delete a post by ID."""
+        if not self._connected or not self._client:
+            raise AuthenticationError("Not authenticated with Mastodon")
+
+        try:
+            self._client.status_delete(post_id)
+            return True
+        except MastodonAPIError:
+            return False
+
+    async def get_post_by_id(self, post_id: str) -> Post | None:
+        """Fetch a specific post by ID."""
+        if not self._connected or not self._client:
+            raise AuthenticationError("Not authenticated with Mastodon")
+
+        try:
+            status = self._client.status(post_id)
+            return self._status_to_post(status)
+        except MastodonAPIError:
+            raise PostNotFoundError(f"Post {post_id} not found on Mastodon")
+
+    def _status_to_post(self, status: dict[str, Any]) -> Post:
+        """Convert a Mastodon status to our Post model."""
+        # Handle reblog (repost)
+        is_repost = status.get("reblog") is not None
+        original_id = None
+        if is_repost:
+            original_id = status["reblog"]["id"]
+            # Use the reblogged content for text
+            content = status["reblog"].get("content", "")
+        else:
+            content = status.get("content", "")
+
+        # Strip HTML tags (basic)
+        import re
+
+        text = re.sub(r"<[^>]+>", "", content)
+        text = text.replace("&amp;", "&").replace("&lt;", "<").replace("&gt;", ">")
+        text = text.replace("&quot;", '"').replace("&#39;", "'")
+
+        # Parse media attachments
+        media_attachments = []
+        for attachment in status.get("media_attachments", []):
+            media_attachments.append(
+                MediaAttachment(
+                    url=attachment["url"],
+                    media_type=attachment["type"],
+                    alt_text=attachment.get("description"),
+                    mime_type=attachment.get("mime_type"),
+                )
+            )
+
+        # Parse created_at
+        created_at = status["created_at"]
+        if isinstance(created_at, str):
+            created_at = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+
+        return Post(
+            id=str(status["id"]),
+            platform="mastodon",
+            text=text.strip(),
+            created_at=created_at,
+            url=status["url"],
+            media_attachments=media_attachments,
+            reply_to_id=status.get("in_reply_to_id"),
+            is_repost=is_repost,
+            original_post_id=str(original_id) if original_id else None,
+            language=status.get("language"),
+            raw_data=status,
+        )

--- a/src/ripplecast/server.py
+++ b/src/ripplecast/server.py
@@ -1,0 +1,581 @@
+"""Ripplecast MCP Server - Cross-posting between Mastodon and Bluesky."""
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from mcp.server.fastmcp import Context, FastMCP
+from mcp.server.session import ServerSession
+
+from ripplecast.matching import build_sync_summary, match_posts_with_llm
+from ripplecast.models import (
+    AuthenticationError,
+    PlatformNotFoundError,
+    PostNotFoundError,
+    PostTooLongError,
+)
+from ripplecast.platform_manager import get_platform_manager
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Create the MCP server
+mcp = FastMCP("Ripplecast")
+
+
+@mcp.tool()
+async def list_platforms() -> dict[str, Any]:
+    """
+    List all configured social media platforms and their connection status.
+
+    Returns platform info including name, display name, connection status,
+    and authenticated username.
+    """
+    manager = await get_platform_manager()
+    statuses = await manager.get_platform_status()
+
+    return {"platforms": statuses}
+
+
+@mcp.tool()
+async def get_posts(
+    platform: str,
+    limit: int = 20,
+    exclude_replies: bool = True,
+    exclude_reposts: bool = True,
+) -> dict[str, Any]:
+    """
+    Get recent posts from a platform.
+
+    Args:
+        platform: Platform name ("mastodon" or "bluesky")
+        limit: Maximum posts to fetch (default 20, max 100)
+        exclude_replies: Skip reply posts (default True)
+        exclude_reposts: Skip reposts/boosts (default True)
+
+    Returns:
+        List of posts with id, text, created_at, url, and media info
+    """
+    manager = await get_platform_manager()
+
+    try:
+        plugin = manager.get_platform(platform)
+
+        if not plugin.connected:
+            return {
+                "success": False,
+                "error": "platform_not_connected",
+                "message": f"Not connected to {platform}",
+            }
+
+        user = await plugin.get_current_user()
+        posts = await manager.get_posts(
+            platform=platform,
+            limit=min(limit, 100),
+            exclude_replies=exclude_replies,
+            exclude_reposts=exclude_reposts,
+        )
+
+        return {
+            "success": True,
+            "platform": platform,
+            "username": user.get("username"),
+            "post_count": len(posts),
+            "posts": [p.to_dict() for p in posts],
+        }
+
+    except PlatformNotFoundError as e:
+        return {
+            "success": False,
+            "error": "platform_not_found",
+            "message": str(e),
+        }
+    except AuthenticationError as e:
+        return {
+            "success": False,
+            "error": "authentication_error",
+            "message": str(e),
+        }
+    except Exception as e:
+        logger.error(f"Error fetching posts from {platform}: {e}")
+        return {
+            "success": False,
+            "error": "fetch_error",
+            "message": str(e),
+        }
+
+
+@mcp.tool()
+async def find_unsynced_posts(
+    source_platform: str | None = None,
+    days_back: int = 7,
+    ctx: Context[ServerSession, Any] = None,
+) -> dict[str, Any]:
+    """
+    Find posts that exist on one platform but not the other.
+
+    Uses Claude (via MCP sampling) to intelligently match posts,
+    handling variations in text, URLs, and formatting.
+
+    Args:
+        source_platform: Only check posts from this platform (optional).
+                        If not specified, checks both directions.
+        days_back: How many days of posts to analyze (default 7)
+
+    Returns:
+        Posts grouped by platform that are missing from other platforms,
+        including any partial matches found
+    """
+    if ctx is None:
+        return {
+            "success": False,
+            "error": "context_required",
+            "message": "This tool requires sampling context",
+        }
+
+    manager = await get_platform_manager()
+
+    try:
+        # Calculate date range
+        end_date = datetime.now(timezone.utc)
+        start_date = end_date - timedelta(days=days_back)
+
+        # Fetch posts from both platforms
+        all_posts = await manager.get_all_posts(
+            limit=50,  # Reasonable batch for comparison
+            exclude_replies=True,
+            exclude_reposts=True,
+        )
+
+        mastodon_posts = all_posts.get("mastodon", [])
+        bluesky_posts = all_posts.get("bluesky", [])
+
+        # Filter by date range
+        mastodon_posts = [p for p in mastodon_posts if p.created_at >= start_date]
+        bluesky_posts = [p for p in bluesky_posts if p.created_at >= start_date]
+
+        if not mastodon_posts and not bluesky_posts:
+            return {
+                "success": True,
+                "message": f"No posts found in the last {days_back} days",
+                "unsynced": {"mastodon_only": [], "bluesky_only": []},
+                "summary": {
+                    "mastodon_only_count": 0,
+                    "bluesky_only_count": 0,
+                    "synced_count": 0,
+                },
+            }
+
+        # Use LLM to match posts
+        matches = await match_posts_with_llm(
+            mastodon_posts,
+            bluesky_posts,
+            ctx,
+            platform_a="Mastodon",
+            platform_b="Bluesky",
+        )
+
+        # Build sync summary
+        summary = build_sync_summary(mastodon_posts, bluesky_posts, matches)
+
+        # Filter by source platform if specified
+        if source_platform == "mastodon":
+            summary["bluesky_only"] = []
+            summary["summary"]["bluesky_only_count"] = 0
+        elif source_platform == "bluesky":
+            summary["mastodon_only"] = []
+            summary["summary"]["mastodon_only_count"] = 0
+
+        return {
+            "success": True,
+            "analysis_period": f"{start_date.strftime('%Y-%m-%d')} to {end_date.strftime('%Y-%m-%d')}",
+            "unsynced": {
+                "mastodon_only": summary["mastodon_only"],
+                "bluesky_only": summary["bluesky_only"],
+            },
+            "already_synced": summary["synced"],
+            "summary": summary["summary"],
+        }
+
+    except Exception as e:
+        logger.error(f"Error finding unsynced posts: {e}")
+        return {
+            "success": False,
+            "error": "sync_check_error",
+            "message": str(e),
+        }
+
+
+@mcp.tool()
+async def cross_post(
+    source_platform: str,
+    post_id: str,
+    target_platform: str,
+    modify_text: str | None = None,
+) -> dict[str, Any]:
+    """
+    Cross-post a post from one platform to another.
+
+    Args:
+        source_platform: Where the original post exists ("mastodon" or "bluesky")
+        post_id: ID of the post to cross-post
+        target_platform: Where to post it ("mastodon" or "bluesky")
+        modify_text: Optional modified text (e.g., to fit character limit).
+                    If not provided, uses original text.
+
+    Returns:
+        Result including new post ID and URL on target platform.
+        If post exceeds character limit, returns error with truncation suggestion.
+
+    Note:
+        Media attachments are NOT automatically transferred (v1 limitation)
+    """
+    manager = await get_platform_manager()
+
+    try:
+        # Get the source post
+        source = manager.get_platform(source_platform)
+        target = manager.get_platform(target_platform)
+
+        if not source.connected:
+            return {
+                "success": False,
+                "error": "source_not_connected",
+                "message": f"Not connected to {source_platform}",
+            }
+
+        if not target.connected:
+            return {
+                "success": False,
+                "error": "target_not_connected",
+                "message": f"Not connected to {target_platform}",
+            }
+
+        # Fetch the original post
+        original_post = await source.get_post_by_id(post_id)
+        if not original_post:
+            return {
+                "success": False,
+                "error": "post_not_found",
+                "message": f"Post {post_id} not found on {source_platform}",
+            }
+
+        # Use modified text or original
+        text_to_post = modify_text if modify_text else original_post.text
+
+        # Validate text length
+        is_valid, error = target.validate_post_content(text_to_post)
+        if not is_valid:
+            # Suggest truncation
+            max_len = target.max_post_length
+            suggested = text_to_post[: max_len - 3] + "..." if len(text_to_post) > max_len else text_to_post
+
+            return {
+                "success": False,
+                "error": "text_too_long",
+                "message": f"Post is {len(text_to_post)} characters but {target_platform} allows max {max_len}",
+                "original_text": text_to_post,
+                "suggested_truncation": suggested,
+                "suggestion": "Use modify_text parameter with shortened version",
+            }
+
+        # Create the post on target platform
+        new_post = await target.create_post(
+            text=text_to_post,
+            language=original_post.language,
+        )
+
+        return {
+            "success": True,
+            "source": {
+                "platform": source_platform,
+                "post_id": post_id,
+                "url": original_post.url,
+            },
+            "target": {
+                "platform": target_platform,
+                "post_id": new_post.id,
+                "url": new_post.url,
+            },
+            "text_used": text_to_post,
+            "synced_at": datetime.now(timezone.utc).isoformat(),
+        }
+
+    except PostNotFoundError as e:
+        return {
+            "success": False,
+            "error": "post_not_found",
+            "message": str(e),
+        }
+    except PostTooLongError as e:
+        return {
+            "success": False,
+            "error": "text_too_long",
+            "message": str(e),
+            "limit": e.limit,
+            "length": e.length,
+        }
+    except PlatformNotFoundError as e:
+        return {
+            "success": False,
+            "error": "platform_not_found",
+            "message": str(e),
+        }
+    except Exception as e:
+        logger.error(f"Error cross-posting: {e}")
+        return {
+            "success": False,
+            "error": "cross_post_error",
+            "message": str(e),
+        }
+
+
+@mcp.tool()
+async def bulk_cross_post(
+    posts: list[dict[str, Any]],
+    dry_run: bool = True,
+) -> dict[str, Any]:
+    """
+    Cross-post multiple posts at once.
+
+    Args:
+        posts: List of dicts with keys:
+               - source_platform: str
+               - post_id: str
+               - target_platform: str
+               - modify_text: str | None (optional)
+        dry_run: If True, only simulate and report what would happen.
+                If False, actually perform the cross-posts.
+
+    Returns:
+        Results for each post (success/failure/skipped)
+
+    Note:
+        ALWAYS run with dry_run=True first and show user the plan.
+        Only run with dry_run=False after explicit user confirmation.
+    """
+    results: list[dict[str, Any]] = []
+
+    for i, post_spec in enumerate(posts):
+        source_platform = post_spec.get("source_platform")
+        post_id = post_spec.get("post_id")
+        target_platform = post_spec.get("target_platform")
+        modify_text = post_spec.get("modify_text")
+
+        if not all([source_platform, post_id, target_platform]):
+            results.append(
+                {
+                    "index": i,
+                    "status": "skipped",
+                    "reason": "Missing required fields",
+                }
+            )
+            continue
+
+        if dry_run:
+            # Just validate and report what would happen
+            manager = await get_platform_manager()
+            try:
+                source = manager.get_platform(source_platform)
+                target = manager.get_platform(target_platform)
+
+                original = await source.get_post_by_id(post_id)
+                if not original:
+                    results.append(
+                        {
+                            "index": i,
+                            "status": "would_fail",
+                            "reason": f"Post {post_id} not found",
+                        }
+                    )
+                    continue
+
+                text = modify_text or original.text
+                is_valid, error = target.validate_post_content(text)
+
+                results.append(
+                    {
+                        "index": i,
+                        "status": "would_succeed" if is_valid else "would_fail",
+                        "source_platform": source_platform,
+                        "target_platform": target_platform,
+                        "text_preview": text[:100] + "..." if len(text) > 100 else text,
+                        "text_length": len(text),
+                        "reason": error if not is_valid else None,
+                    }
+                )
+
+            except Exception as e:
+                results.append(
+                    {
+                        "index": i,
+                        "status": "would_fail",
+                        "reason": str(e),
+                    }
+                )
+        else:
+            # Actually perform the cross-post
+            result = await cross_post(
+                source_platform=source_platform,
+                post_id=post_id,
+                target_platform=target_platform,
+                modify_text=modify_text,
+            )
+
+            results.append(
+                {
+                    "index": i,
+                    "status": "success" if result.get("success") else "failed",
+                    "result": result,
+                }
+            )
+
+    success_count = sum(
+        1
+        for r in results
+        if r["status"] in ("success", "would_succeed")
+    )
+    fail_count = sum(
+        1
+        for r in results
+        if r["status"] in ("failed", "would_fail")
+    )
+
+    return {
+        "dry_run": dry_run,
+        "total": len(posts),
+        "success_count": success_count,
+        "fail_count": fail_count,
+        "results": results,
+        "message": "This is a dry run - no posts were created"
+        if dry_run
+        else f"Completed: {success_count} succeeded, {fail_count} failed",
+    }
+
+
+@mcp.tool()
+async def get_sync_status(
+    platform: str,
+    post_id: str,
+    ctx: Context[ServerSession, Any] = None,
+) -> dict[str, Any]:
+    """
+    Check if a post exists on other platforms (i.e., has been synced).
+
+    Uses content matching to find the same post across platforms.
+
+    Args:
+        platform: Platform where the post exists ("mastodon" or "bluesky")
+        post_id: ID of the post to check
+
+    Returns:
+        Status showing which platforms have matching posts
+    """
+    manager = await get_platform_manager()
+
+    try:
+        source = manager.get_platform(platform)
+        if not source.connected:
+            return {
+                "success": False,
+                "error": "platform_not_connected",
+                "message": f"Not connected to {platform}",
+            }
+
+        # Get the source post
+        post = await source.get_post_by_id(post_id)
+        if not post:
+            return {
+                "success": False,
+                "error": "post_not_found",
+                "message": f"Post {post_id} not found on {platform}",
+            }
+
+        # Determine target platform
+        target_platform = "bluesky" if platform == "mastodon" else "mastodon"
+        target = manager.get_platform(target_platform)
+
+        synced_to = []
+        not_synced_to = []
+
+        if target.connected and ctx:
+            # Get recent posts from target platform
+            target_posts = await manager.get_posts(
+                target_platform,
+                limit=50,
+                exclude_replies=True,
+                exclude_reposts=True,
+            )
+
+            # Use LLM to find matches
+            matches = await match_posts_with_llm(
+                [post],
+                target_posts,
+                ctx,
+                platform_a=platform.title(),
+                platform_b=target_platform.title(),
+            )
+
+            if matches:
+                for match in matches:
+                    matched_post = next(
+                        (p for p in target_posts if p.id == match.post_b_id),
+                        None,
+                    )
+                    if matched_post:
+                        synced_to.append(
+                            {
+                                "platform": target_platform,
+                                "post_id": matched_post.id,
+                                "url": matched_post.url,
+                                "similarity": match.confidence,
+                                "match_type": match.reason,
+                            }
+                        )
+            else:
+                not_synced_to.append(target_platform)
+        elif not target.connected:
+            not_synced_to.append(f"{target_platform} (not connected)")
+
+        return {
+            "success": True,
+            "source": {
+                "platform": platform,
+                "post_id": post_id,
+                "text": post.text,
+                "created_at": post.created_at.isoformat(),
+                "url": post.url,
+            },
+            "synced_to": synced_to,
+            "not_synced_to": not_synced_to,
+        }
+
+    except PostNotFoundError as e:
+        return {
+            "success": False,
+            "error": "post_not_found",
+            "message": str(e),
+        }
+    except PlatformNotFoundError as e:
+        return {
+            "success": False,
+            "error": "platform_not_found",
+            "message": str(e),
+        }
+    except Exception as e:
+        logger.error(f"Error checking sync status: {e}")
+        return {
+            "success": False,
+            "error": "sync_status_error",
+            "message": str(e),
+        }
+
+
+def main() -> None:
+    """Run the MCP server."""
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Ripplecast."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,156 @@
+"""Pytest configuration and shared fixtures."""
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ripplecast.config import BlueskyConfig, MastodonConfig
+from ripplecast.models import Post
+
+
+@pytest.fixture
+def mastodon_config():
+    """Create a test Mastodon config."""
+    return MastodonConfig(
+        instance_url="https://mastodon.social",
+        access_token="test_token",
+    )
+
+
+@pytest.fixture
+def bluesky_config():
+    """Create a test Bluesky config."""
+    return BlueskyConfig(
+        handle="test.bsky.social",
+        app_password="xxxx-xxxx-xxxx-xxxx",
+    )
+
+
+@pytest.fixture
+def sample_mastodon_post():
+    """Create a sample Mastodon post."""
+    return Post(
+        id="123456789",
+        platform="mastodon",
+        text="Hello world! This is a test post.",
+        created_at=datetime(2025, 1, 25, 10, 0, 0, tzinfo=timezone.utc),
+        url="https://mastodon.social/@testuser/123456789",
+    )
+
+
+@pytest.fixture
+def sample_bluesky_post():
+    """Create a sample Bluesky post."""
+    return Post(
+        id="at://did:plc:test/app.bsky.feed.post/abc123",
+        platform="bluesky",
+        text="Hello world! This is a test post.",
+        created_at=datetime(2025, 1, 25, 10, 2, 0, tzinfo=timezone.utc),
+        url="https://bsky.app/profile/test.bsky.social/post/abc123",
+    )
+
+
+@pytest.fixture
+def sample_mastodon_posts():
+    """Create a list of sample Mastodon posts."""
+    return [
+        Post(
+            id="111",
+            platform="mastodon",
+            text="First post on Mastodon",
+            created_at=datetime(2025, 1, 25, 10, 0, 0, tzinfo=timezone.utc),
+            url="https://mastodon.social/@testuser/111",
+        ),
+        Post(
+            id="222",
+            platform="mastodon",
+            text="Second post with a link https://example.com",
+            created_at=datetime(2025, 1, 24, 15, 30, 0, tzinfo=timezone.utc),
+            url="https://mastodon.social/@testuser/222",
+        ),
+        Post(
+            id="333",
+            platform="mastodon",
+            text="Third post only on Mastodon",
+            created_at=datetime(2025, 1, 23, 9, 0, 0, tzinfo=timezone.utc),
+            url="https://mastodon.social/@testuser/333",
+        ),
+    ]
+
+
+@pytest.fixture
+def sample_bluesky_posts():
+    """Create a list of sample Bluesky posts."""
+    return [
+        Post(
+            id="at://did:plc:test/app.bsky.feed.post/aaa",
+            platform="bluesky",
+            text="First post on Mastodon",  # Same as mastodon post 111
+            created_at=datetime(2025, 1, 25, 10, 5, 0, tzinfo=timezone.utc),
+            url="https://bsky.app/profile/test.bsky.social/post/aaa",
+        ),
+        Post(
+            id="at://did:plc:test/app.bsky.feed.post/bbb",
+            platform="bluesky",
+            text="Unique post only on Bluesky",
+            created_at=datetime(2025, 1, 24, 12, 0, 0, tzinfo=timezone.utc),
+            url="https://bsky.app/profile/test.bsky.social/post/bbb",
+        ),
+    ]
+
+
+@pytest.fixture
+def mock_mastodon_client(mocker):
+    """Create a mock Mastodon client."""
+    mock = mocker.patch("ripplecast.platforms.mastodon.Mastodon")
+
+    # Set up mock instance
+    instance = mock.return_value
+    instance.account_verify_credentials.return_value = {
+        "id": "12345",
+        "username": "testuser",
+        "display_name": "Test User",
+        "url": "https://mastodon.social/@testuser",
+    }
+    instance.instance.return_value = {
+        "max_toot_chars": 500,
+    }
+    instance.me.return_value = {"id": "12345"}
+
+    return mock
+
+
+@pytest.fixture
+def mock_bluesky_client(mocker):
+    """Create a mock Bluesky client."""
+    mock = mocker.patch("ripplecast.platforms.bluesky.Client")
+
+    # Set up mock instance
+    instance = mock.return_value
+    instance.me = MagicMock()
+    instance.me.did = "did:plc:test"
+
+    profile = MagicMock()
+    profile.handle = "test.bsky.social"
+    profile.display_name = "Test User"
+    instance.get_profile.return_value = profile
+
+    return mock
+
+
+@pytest.fixture
+def fixtures_path():
+    """Get the path to test fixtures."""
+    return Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture
+def load_fixture(fixtures_path):
+    """Load a JSON fixture file."""
+    def _load(name: str) -> dict:
+        with open(fixtures_path / f"{name}.json") as f:
+            return json.load(f)
+    return _load

--- a/tests/fixtures/bluesky_posts.json
+++ b/tests/fixtures/bluesky_posts.json
@@ -1,0 +1,32 @@
+[
+  {
+    "uri": "at://did:plc:testuser123/app.bsky.feed.post/3abc123def",
+    "cid": "bafyreiabc123",
+    "author": {
+      "did": "did:plc:testuser123",
+      "handle": "testuser.bsky.social",
+      "displayName": "Test User"
+    },
+    "record": {
+      "text": "Hello world! This is my first cross-posted test.",
+      "createdAt": "2025-01-25T10:05:00.000Z",
+      "langs": ["en"]
+    },
+    "indexedAt": "2025-01-25T10:05:01.000Z"
+  },
+  {
+    "uri": "at://did:plc:testuser123/app.bsky.feed.post/3abc123ghi",
+    "cid": "bafyreighi456",
+    "author": {
+      "did": "did:plc:testuser123",
+      "handle": "testuser.bsky.social",
+      "displayName": "Test User"
+    },
+    "record": {
+      "text": "Unique Bluesky post not on Mastodon",
+      "createdAt": "2025-01-24T12:00:00.000Z",
+      "langs": ["en"]
+    },
+    "indexedAt": "2025-01-24T12:00:01.000Z"
+  }
+]

--- a/tests/fixtures/mastodon_posts.json
+++ b/tests/fixtures/mastodon_posts.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": "111222333444555666",
+    "created_at": "2025-01-25T10:00:00.000Z",
+    "content": "<p>Hello world! This is my first cross-posted test.</p>",
+    "url": "https://mastodon.social/@testuser/111222333444555666",
+    "reblog": null,
+    "in_reply_to_id": null,
+    "language": "en",
+    "media_attachments": []
+  },
+  {
+    "id": "111222333444555667",
+    "created_at": "2025-01-24T15:30:00.000Z",
+    "content": "<p>Check out this great article! <a href=\"https://example.com/article\">https://example.com/article</a></p>",
+    "url": "https://mastodon.social/@testuser/111222333444555667",
+    "reblog": null,
+    "in_reply_to_id": null,
+    "language": "en",
+    "media_attachments": []
+  },
+  {
+    "id": "111222333444555668",
+    "created_at": "2025-01-23T09:00:00.000Z",
+    "content": "<p>Morning thoughts on software development...</p>",
+    "url": "https://mastodon.social/@testuser/111222333444555668",
+    "reblog": null,
+    "in_reply_to_id": null,
+    "language": "en",
+    "media_attachments": []
+  }
+]

--- a/tests/test_bluesky.py
+++ b/tests/test_bluesky.py
@@ -1,0 +1,89 @@
+"""Tests for Bluesky platform plugin."""
+
+import pytest
+
+from ripplecast.models import AuthenticationError
+from ripplecast.platforms.bluesky import BlueskyPlugin
+
+
+class TestBlueskyPlugin:
+    """Tests for the BlueskyPlugin class."""
+
+    def test_platform_properties(self, bluesky_config):
+        """Test platform property values."""
+        plugin = BlueskyPlugin(bluesky_config)
+
+        assert plugin.platform_name == "bluesky"
+        assert plugin.display_name == "Bluesky"
+        assert plugin.max_post_length == 300
+        assert plugin.connected is False
+
+    @pytest.mark.asyncio
+    async def test_authenticate_success(self, bluesky_config, mock_bluesky_client):
+        """Test successful authentication."""
+        plugin = BlueskyPlugin(bluesky_config)
+
+        result = await plugin.authenticate()
+
+        assert result is True
+        assert plugin.connected is True
+
+    @pytest.mark.asyncio
+    async def test_authenticate_not_configured(self):
+        """Test authentication with missing config."""
+        from ripplecast.config import BlueskyConfig
+
+        config = BlueskyConfig(handle="", app_password="")
+        plugin = BlueskyPlugin(config)
+
+        result = await plugin.authenticate()
+
+        assert result is False
+        assert plugin.connected is False
+
+    @pytest.mark.asyncio
+    async def test_get_current_user_not_authenticated(self, bluesky_config):
+        """Test getting user when not authenticated."""
+        plugin = BlueskyPlugin(bluesky_config)
+
+        with pytest.raises(AuthenticationError):
+            await plugin.get_current_user()
+
+    def test_validate_post_content_valid(self, bluesky_config):
+        """Test validating valid post content."""
+        plugin = BlueskyPlugin(bluesky_config)
+
+        is_valid, error = plugin.validate_post_content("Hello world!")
+
+        assert is_valid is True
+        assert error is None
+
+    def test_validate_post_content_too_long(self, bluesky_config):
+        """Test validating post that's too long."""
+        plugin = BlueskyPlugin(bluesky_config)
+        long_text = "x" * 350
+
+        is_valid, error = plugin.validate_post_content(long_text)
+
+        assert is_valid is False
+        assert "exceeds 300" in error
+
+    def test_validate_post_at_limit(self, bluesky_config):
+        """Test validating post exactly at the limit."""
+        plugin = BlueskyPlugin(bluesky_config)
+        text = "x" * 300
+
+        is_valid, error = plugin.validate_post_content(text)
+
+        assert is_valid is True
+        assert error is None
+
+    def test_uri_to_url(self, bluesky_config):
+        """Test converting AT Protocol URI to bsky.app URL."""
+        plugin = BlueskyPlugin(bluesky_config)
+        uri = "at://did:plc:test123/app.bsky.feed.post/abc456"
+
+        url = plugin._uri_to_url(uri)
+
+        assert "bsky.app/profile" in url
+        assert "abc456" in url

--- a/tests/test_mastodon.py
+++ b/tests/test_mastodon.py
@@ -1,0 +1,135 @@
+"""Tests for Mastodon platform plugin."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from ripplecast.models import AuthenticationError, PostTooLongError
+from ripplecast.platforms.mastodon import MastodonPlugin
+
+
+class TestMastodonPlugin:
+    """Tests for the MastodonPlugin class."""
+
+    def test_platform_properties(self, mastodon_config):
+        """Test platform property values."""
+        plugin = MastodonPlugin(mastodon_config)
+
+        assert plugin.platform_name == "mastodon"
+        assert plugin.display_name == "Mastodon"
+        assert plugin.max_post_length == 500  # Default before auth
+        assert plugin.connected is False
+
+    @pytest.mark.asyncio
+    async def test_authenticate_success(self, mastodon_config, mock_mastodon_client):
+        """Test successful authentication."""
+        plugin = MastodonPlugin(mastodon_config)
+
+        result = await plugin.authenticate()
+
+        assert result is True
+        assert plugin.connected is True
+
+    @pytest.mark.asyncio
+    async def test_authenticate_not_configured(self):
+        """Test authentication with missing config."""
+        from ripplecast.config import MastodonConfig
+
+        config = MastodonConfig(instance_url="", access_token="")
+        plugin = MastodonPlugin(config)
+
+        result = await plugin.authenticate()
+
+        assert result is False
+        assert plugin.connected is False
+
+    @pytest.mark.asyncio
+    async def test_get_current_user_not_authenticated(self, mastodon_config):
+        """Test getting user when not authenticated."""
+        plugin = MastodonPlugin(mastodon_config)
+
+        with pytest.raises(AuthenticationError):
+            await plugin.get_current_user()
+
+    def test_validate_post_content_valid(self, mastodon_config):
+        """Test validating valid post content."""
+        plugin = MastodonPlugin(mastodon_config)
+
+        is_valid, error = plugin.validate_post_content("Hello world!")
+
+        assert is_valid is True
+        assert error is None
+
+    def test_validate_post_content_too_long(self, mastodon_config):
+        """Test validating post that's too long."""
+        plugin = MastodonPlugin(mastodon_config)
+        long_text = "x" * 600
+
+        is_valid, error = plugin.validate_post_content(long_text)
+
+        assert is_valid is False
+        assert "exceeds 500" in error
+
+    def test_status_to_post_basic(self, mastodon_config):
+        """Test converting Mastodon status to Post."""
+        plugin = MastodonPlugin(mastodon_config)
+        status = {
+            "id": "123",
+            "content": "<p>Hello world!</p>",
+            "created_at": datetime(2025, 1, 25, 10, 0, 0, tzinfo=timezone.utc),
+            "url": "https://mastodon.social/@user/123",
+            "reblog": None,
+            "media_attachments": [],
+            "in_reply_to_id": None,
+            "language": "en",
+        }
+
+        post = plugin._status_to_post(status)
+
+        assert post.id == "123"
+        assert post.platform == "mastodon"
+        assert post.text == "Hello world!"
+        assert post.url == "https://mastodon.social/@user/123"
+        assert post.is_repost is False
+        assert post.language == "en"
+
+    def test_status_to_post_with_html_entities(self, mastodon_config):
+        """Test converting status with HTML entities."""
+        plugin = MastodonPlugin(mastodon_config)
+        status = {
+            "id": "456",
+            "content": "<p>This &amp; that &lt;tag&gt; &quot;quoted&quot;</p>",
+            "created_at": datetime.now(timezone.utc),
+            "url": "https://mastodon.social/@user/456",
+            "reblog": None,
+            "media_attachments": [],
+            "in_reply_to_id": None,
+            "language": None,
+        }
+
+        post = plugin._status_to_post(status)
+
+        assert post.text == 'This & that <tag> "quoted"'
+
+    def test_status_to_post_reblog(self, mastodon_config):
+        """Test converting a reblog status."""
+        plugin = MastodonPlugin(mastodon_config)
+        status = {
+            "id": "789",
+            "content": "",
+            "created_at": datetime.now(timezone.utc),
+            "url": "https://mastodon.social/@user/789",
+            "reblog": {
+                "id": "original123",
+                "content": "<p>Original post content</p>",
+            },
+            "media_attachments": [],
+            "in_reply_to_id": None,
+            "language": None,
+        }
+
+        post = plugin._status_to_post(status)
+
+        assert post.is_repost is True
+        assert post.original_post_id == "original123"
+        assert post.text == "Original post content"

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -1,0 +1,101 @@
+"""Tests for post matching service."""
+
+import pytest
+
+from ripplecast.matching import build_sync_summary, find_unmatched_posts
+from ripplecast.models import PostMatch
+
+
+class TestFindUnmatchedPosts:
+    """Tests for find_unmatched_posts function."""
+
+    def test_finds_unmatched_posts_platform_a(self, sample_mastodon_posts):
+        """Test finding unmatched posts from platform A."""
+        matches = [
+            PostMatch(
+                post_a_id="111",
+                post_b_id="aaa",
+                confidence=1.0,
+                reason="identical",
+            )
+        ]
+
+        unmatched = find_unmatched_posts(sample_mastodon_posts, matches, "a")
+
+        assert len(unmatched) == 2
+        assert unmatched[0].id == "222"
+        assert unmatched[1].id == "333"
+
+    def test_finds_unmatched_posts_platform_b(self, sample_bluesky_posts):
+        """Test finding unmatched posts from platform B."""
+        matches = [
+            PostMatch(
+                post_a_id="111",
+                post_b_id="at://did:plc:test/app.bsky.feed.post/aaa",
+                confidence=1.0,
+                reason="identical",
+            )
+        ]
+
+        unmatched = find_unmatched_posts(sample_bluesky_posts, matches, "b")
+
+        assert len(unmatched) == 1
+        assert unmatched[0].id == "at://did:plc:test/app.bsky.feed.post/bbb"
+
+    def test_no_matches_returns_all(self, sample_mastodon_posts):
+        """Test that no matches returns all posts."""
+        matches = []
+
+        unmatched = find_unmatched_posts(sample_mastodon_posts, matches, "a")
+
+        assert len(unmatched) == len(sample_mastodon_posts)
+
+    def test_all_matched_returns_empty(self, sample_mastodon_posts):
+        """Test that all matched returns empty list."""
+        matches = [
+            PostMatch(post_a_id="111", post_b_id="x", confidence=1.0, reason=""),
+            PostMatch(post_a_id="222", post_b_id="y", confidence=1.0, reason=""),
+            PostMatch(post_a_id="333", post_b_id="z", confidence=1.0, reason=""),
+        ]
+
+        unmatched = find_unmatched_posts(sample_mastodon_posts, matches, "a")
+
+        assert len(unmatched) == 0
+
+
+class TestBuildSyncSummary:
+    """Tests for build_sync_summary function."""
+
+    def test_builds_correct_summary(self, sample_mastodon_posts, sample_bluesky_posts):
+        """Test building a sync summary."""
+        matches = [
+            PostMatch(
+                post_a_id="111",
+                post_b_id="at://did:plc:test/app.bsky.feed.post/aaa",
+                confidence=1.0,
+                reason="identical text",
+            )
+        ]
+
+        summary = build_sync_summary(sample_mastodon_posts, sample_bluesky_posts, matches)
+
+        assert len(summary["mastodon_only"]) == 2
+        assert len(summary["bluesky_only"]) == 1
+        assert len(summary["synced"]) == 1
+
+        assert summary["summary"]["mastodon_only_count"] == 2
+        assert summary["summary"]["bluesky_only_count"] == 1
+        assert summary["summary"]["synced_count"] == 1
+        assert summary["summary"]["total_mastodon"] == 3
+        assert summary["summary"]["total_bluesky"] == 2
+
+    def test_empty_posts(self):
+        """Test with empty post lists."""
+        summary = build_sync_summary([], [], [])
+
+        assert summary["mastodon_only"] == []
+        assert summary["bluesky_only"] == []
+        assert summary["synced"] == []
+        assert summary["summary"]["mastodon_only_count"] == 0
+        assert summary["summary"]["bluesky_only_count"] == 0
+        assert summary["summary"]["synced_count"] == 0

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,124 @@
+"""Tests for data models."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from ripplecast.models import (
+    MediaAttachment,
+    Post,
+    PostMatch,
+    PostTooLongError,
+    RateLimitError,
+)
+
+
+class TestPost:
+    """Tests for the Post model."""
+
+    def test_post_creation(self):
+        """Test creating a basic post."""
+        post = Post(
+            id="123",
+            platform="mastodon",
+            text="Hello world!",
+            created_at=datetime(2025, 1, 25, 10, 0, 0, tzinfo=timezone.utc),
+            url="https://example.com/123",
+        )
+
+        assert post.id == "123"
+        assert post.platform == "mastodon"
+        assert post.text == "Hello world!"
+        assert post.url == "https://example.com/123"
+        assert post.media_attachments == []
+        assert post.is_repost is False
+
+    def test_post_to_dict(self):
+        """Test converting post to dictionary."""
+        post = Post(
+            id="123",
+            platform="bluesky",
+            text="Test post",
+            created_at=datetime(2025, 1, 25, 10, 0, 0, tzinfo=timezone.utc),
+            url="https://bsky.app/post/123",
+        )
+
+        result = post.to_dict()
+
+        assert result["id"] == "123"
+        assert result["platform"] == "bluesky"
+        assert result["text"] == "Test post"
+        assert result["has_media"] is False
+        assert result["is_reply"] is False
+        assert result["is_repost"] is False
+
+    def test_post_with_media(self):
+        """Test post with media attachments."""
+        media = MediaAttachment(
+            url="https://example.com/image.png",
+            media_type="image",
+            alt_text="A test image",
+        )
+        post = Post(
+            id="123",
+            platform="mastodon",
+            text="Check this out!",
+            created_at=datetime.now(timezone.utc),
+            url="https://example.com/123",
+            media_attachments=[media],
+        )
+
+        assert len(post.media_attachments) == 1
+        assert post.to_dict()["has_media"] is True
+        assert post.to_dict()["media_count"] == 1
+
+
+class TestPostMatch:
+    """Tests for the PostMatch model."""
+
+    def test_post_match_creation(self):
+        """Test creating a post match."""
+        match = PostMatch(
+            post_a_id="123",
+            post_b_id="456",
+            confidence=0.95,
+            reason="identical text",
+        )
+
+        assert match.post_a_id == "123"
+        assert match.post_b_id == "456"
+        assert match.confidence == 0.95
+        assert match.reason == "identical text"
+
+
+class TestExceptions:
+    """Tests for custom exceptions."""
+
+    def test_post_too_long_error(self):
+        """Test PostTooLongError."""
+        text = "x" * 350
+        error = PostTooLongError(text, 300, "bluesky")
+
+        assert error.text == text
+        assert error.limit == 300
+        assert error.platform == "bluesky"
+        assert error.length == 350
+        assert "350 chars" in str(error)
+        assert "bluesky" in str(error)
+        assert "max 300" in str(error)
+
+    def test_rate_limit_error_without_retry(self):
+        """Test RateLimitError without retry_after."""
+        error = RateLimitError("mastodon")
+
+        assert error.platform == "mastodon"
+        assert error.retry_after is None
+        assert "Rate limited by mastodon" in str(error)
+
+    def test_rate_limit_error_with_retry(self):
+        """Test RateLimitError with retry_after."""
+        error = RateLimitError("bluesky", retry_after=60)
+
+        assert error.platform == "bluesky"
+        assert error.retry_after == 60
+        assert "retry after 60 seconds" in str(error)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,189 @@
+"""Tests for the MCP server tools."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class TestServerTools:
+    """Tests for MCP server tool functions."""
+
+    @pytest.mark.asyncio
+    async def test_list_platforms(self):
+        """Test list_platforms tool."""
+        from ripplecast.server import list_platforms
+
+        with patch("ripplecast.server.get_platform_manager") as mock_get_manager:
+            mock_manager = AsyncMock()
+            mock_manager.get_platform_status.return_value = [
+                {
+                    "name": "mastodon",
+                    "display_name": "Mastodon",
+                    "connected": True,
+                    "username": "@test@mastodon.social",
+                },
+                {
+                    "name": "bluesky",
+                    "display_name": "Bluesky",
+                    "connected": False,
+                    "error": "Not authenticated",
+                },
+            ]
+            mock_get_manager.return_value = mock_manager
+
+            result = await list_platforms()
+
+            assert "platforms" in result
+            assert len(result["platforms"]) == 2
+            assert result["platforms"][0]["name"] == "mastodon"
+            assert result["platforms"][0]["connected"] is True
+
+    @pytest.mark.asyncio
+    async def test_get_posts_success(self, sample_mastodon_posts):
+        """Test get_posts tool with successful response."""
+        from ripplecast.server import get_posts
+
+        with patch("ripplecast.server.get_platform_manager") as mock_get_manager:
+            mock_plugin = MagicMock()
+            mock_plugin.connected = True
+            mock_plugin.get_current_user = AsyncMock(
+                return_value={"username": "@test@mastodon.social"}
+            )
+
+            mock_manager = AsyncMock()
+            mock_manager.get_platform.return_value = mock_plugin
+            mock_manager.get_posts.return_value = sample_mastodon_posts
+            mock_get_manager.return_value = mock_manager
+
+            result = await get_posts(platform="mastodon", limit=20)
+
+            assert result["success"] is True
+            assert result["platform"] == "mastodon"
+            assert result["post_count"] == 3
+
+    @pytest.mark.asyncio
+    async def test_get_posts_not_connected(self):
+        """Test get_posts when platform is not connected."""
+        from ripplecast.server import get_posts
+
+        with patch("ripplecast.server.get_platform_manager") as mock_get_manager:
+            mock_plugin = MagicMock()
+            mock_plugin.connected = False
+
+            mock_manager = AsyncMock()
+            mock_manager.get_platform.return_value = mock_plugin
+            mock_get_manager.return_value = mock_manager
+
+            result = await get_posts(platform="mastodon")
+
+            assert result["success"] is False
+            assert result["error"] == "platform_not_connected"
+
+    @pytest.mark.asyncio
+    async def test_cross_post_success(self, sample_mastodon_post):
+        """Test cross_post tool with successful response."""
+        from ripplecast.server import cross_post
+
+        with patch("ripplecast.server.get_platform_manager") as mock_get_manager:
+            # Source plugin
+            mock_source = MagicMock()
+            mock_source.connected = True
+            mock_source.get_post_by_id = AsyncMock(return_value=sample_mastodon_post)
+
+            # Target plugin
+            mock_target = MagicMock()
+            mock_target.connected = True
+            mock_target.validate_post_content.return_value = (True, None)
+            mock_target.create_post = AsyncMock(
+                return_value=MagicMock(
+                    id="new123",
+                    url="https://bsky.app/post/new123",
+                )
+            )
+
+            mock_manager = AsyncMock()
+            mock_manager.get_platform.side_effect = lambda p: (
+                mock_source if p == "mastodon" else mock_target
+            )
+            mock_get_manager.return_value = mock_manager
+
+            result = await cross_post(
+                source_platform="mastodon",
+                post_id="123456789",
+                target_platform="bluesky",
+            )
+
+            assert result["success"] is True
+            assert result["source"]["platform"] == "mastodon"
+            assert result["target"]["platform"] == "bluesky"
+
+    @pytest.mark.asyncio
+    async def test_cross_post_text_too_long(self, sample_mastodon_post):
+        """Test cross_post when text exceeds target limit."""
+        from ripplecast.server import cross_post
+
+        # Make the post text too long for Bluesky
+        sample_mastodon_post.text = "x" * 350
+
+        with patch("ripplecast.server.get_platform_manager") as mock_get_manager:
+            mock_source = MagicMock()
+            mock_source.connected = True
+            mock_source.get_post_by_id = AsyncMock(return_value=sample_mastodon_post)
+
+            mock_target = MagicMock()
+            mock_target.connected = True
+            mock_target.max_post_length = 300
+            mock_target.validate_post_content.return_value = (
+                False,
+                "Post exceeds 300 characters",
+            )
+
+            mock_manager = AsyncMock()
+            mock_manager.get_platform.side_effect = lambda p: (
+                mock_source if p == "mastodon" else mock_target
+            )
+            mock_get_manager.return_value = mock_manager
+
+            result = await cross_post(
+                source_platform="mastodon",
+                post_id="123456789",
+                target_platform="bluesky",
+            )
+
+            assert result["success"] is False
+            assert result["error"] == "text_too_long"
+            assert "suggested_truncation" in result
+
+    @pytest.mark.asyncio
+    async def test_bulk_cross_post_dry_run(self, sample_mastodon_post):
+        """Test bulk_cross_post in dry run mode."""
+        from ripplecast.server import bulk_cross_post
+
+        with patch("ripplecast.server.get_platform_manager") as mock_get_manager:
+            mock_source = MagicMock()
+            mock_source.connected = True
+            mock_source.get_post_by_id = AsyncMock(return_value=sample_mastodon_post)
+
+            mock_target = MagicMock()
+            mock_target.connected = True
+            mock_target.validate_post_content.return_value = (True, None)
+
+            mock_manager = AsyncMock()
+            mock_manager.get_platform.side_effect = lambda p: (
+                mock_source if p == "mastodon" else mock_target
+            )
+            mock_get_manager.return_value = mock_manager
+
+            posts = [
+                {
+                    "source_platform": "mastodon",
+                    "post_id": "123",
+                    "target_platform": "bluesky",
+                }
+            ]
+
+            result = await bulk_cross_post(posts=posts, dry_run=True)
+
+            assert result["dry_run"] is True
+            assert result["total"] == 1
+            assert result["results"][0]["status"] == "would_succeed"


### PR DESCRIPTION
## Summary

- Implements the complete v1 specification for Ripplecast MCP server
- Enables cross-posting between Mastodon and Bluesky via Claude Desktop
- Provides 6 MCP tools for viewing, comparing, and syncing posts across platforms

## Implementation Details

### MCP Tools
| Tool | Description |
|------|-------------|
| `list_platforms` | List configured platforms and connection status |
| `get_posts` | Fetch recent posts from a platform |
| `find_unsynced_posts` | Find posts missing from other platforms (uses LLM sampling) |
| `cross_post` | Cross-post a single post with optional text modification |
| `bulk_cross_post` | Cross-post multiple posts with dry-run support |
| `get_sync_status` | Check if a specific post has been synced |

### Architecture
- **FastMCP** for MCP protocol handling
- **Plugin architecture** via abstract `PlatformPlugin` base class
- **Mastodon plugin** using Mastodon.py library
- **Bluesky plugin** using atproto library
- **LLM-based post matching** via MCP sampling for intelligent duplicate detection

### Key Files
- `src/ripplecast/server.py` - MCP server entry point
- `src/ripplecast/platforms/` - Platform plugin implementations
- `src/ripplecast/matching.py` - LLM-based post matching
- `src/ripplecast/models.py` - Data models and exceptions

## Test plan

- [ ] Run `pytest tests/` to verify all unit tests pass
- [ ] Verify pyproject.toml dependencies are correct
- [ ] Test with MCP Inspector: `npx @modelcontextprotocol/inspector python -m ripplecast.server`
- [ ] Configure in Claude Desktop and verify tools are available

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)