### PR TITLE
Improve sync status detection (#9)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,8 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(gh issue view:*)",
-      "Bash(tree:*)"
-    ]
-  }
-}

--- a/src/ripplecast/matching.py
+++ b/src/ripplecast/matching.py
@@ -71,7 +71,6 @@ Only include matches with confidence >= 0.7. Consider:
 - Exact or near-exact text matches
 - Same content with minor edits (typos, length adjustments)
 - Same links or media references
-- Posted within similar timeframes
 
 If no matches found, return an empty array: []
 

--- a/src/ripplecast/platforms/base.py
+++ b/src/ripplecast/platforms/base.py
@@ -132,3 +132,11 @@ class PlatformPlugin(ABC):
         if len(text) > self.max_post_length:
             return False, f"Post exceeds {self.max_post_length} characters (got {len(text)})"
         return True, None
+
+    @abstractmethod
+    def is_posted_via_ripplecast(self, post: Post) -> bool:
+        """
+        Check if a post's metadata indicates it was created via ripplecast.
+        Return False if the platform has no attribution mechanism.
+        """
+        pass

--- a/src/ripplecast/platforms/bluesky.py
+++ b/src/ripplecast/platforms/bluesky.py
@@ -232,7 +232,15 @@ class BlueskyPlugin(PlatformPlugin):
                     external.thumb = thumb_response.blob
                 embed = models.AppBskyEmbedExternal.Main(external=external)
 
-            response = self._client.send_post(text=text, embed=embed)
+            record = models.AppBskyFeedPost.Record(
+                created_at=self._client.get_current_time_iso(),
+                text=text,
+                embed=embed,
+                via="ripplecast",
+            )
+            response = self._client.app.bsky.feed.post.create(
+                self._client.me.did, record
+            )
 
             # Return the created post
             return Post(
@@ -241,7 +249,7 @@ class BlueskyPlugin(PlatformPlugin):
                 text=text,
                 created_at=datetime.now(),
                 url=self._uri_to_url(response.uri),
-                raw_data={"uri": response.uri, "cid": response.cid},
+                raw_data={"uri": response.uri, "cid": response.cid, "via": "ripplecast"},
             )
 
         except AtProtocolError as e:
@@ -312,7 +320,7 @@ class BlueskyPlugin(PlatformPlugin):
                 url=self._uri_to_url(response.uri),
                 media_attachments=media_attachments,
                 link_embed=link_embed,
-                raw_data={"uri": response.uri, "cid": response.cid},
+                raw_data={"uri": response.uri, "cid": response.cid, "via": getattr(response.value, "via", None)},
             )
 
         except AtProtocolError:
@@ -374,8 +382,13 @@ class BlueskyPlugin(PlatformPlugin):
                 if hasattr(post.record, "langs") and post.record.langs
                 else None
             ),
-            raw_data={"uri": post.uri, "cid": post.cid},
+            raw_data={"uri": post.uri, "cid": post.cid, "via": getattr(post.record, "via", None)},
         )
+
+    def is_posted_via_ripplecast(self, post: Post) -> bool:
+        """Check for a 'via' field in raw_data populated when ripplecast creates posts."""
+        via = post.raw_data.get("via", "")
+        return isinstance(via, str) and "ripplecast" in via.lower()
 
     def _uri_to_url(self, uri: str) -> str:
         """Convert an AT Protocol URI to a bsky.app URL."""

--- a/src/ripplecast/platforms/mastodon.py
+++ b/src/ripplecast/platforms/mastodon.py
@@ -201,6 +201,14 @@ class MastodonPlugin(PlatformPlugin):
         except MastodonAPIError:
             raise PostNotFoundError(f"Post {post_id} not found on Mastodon")
 
+    def is_posted_via_ripplecast(self, post: Post) -> bool:
+        """Check Mastodon's application field for the ripplecast app name."""
+        application = post.raw_data.get("application")
+        if isinstance(application, dict):
+            app_name = application.get("name", "").lower()
+            return "ripplecast" in app_name
+        return False
+
     def _status_to_post(self, status: dict[str, Any]) -> Post:
         """Convert a Mastodon status to our Post model."""
         # Handle reblog (repost)

--- a/src/ripplecast/server.py
+++ b/src/ripplecast/server.py
@@ -161,9 +161,11 @@ async def find_unsynced_posts(
         mastodon_posts = []
         bluesky_posts = []
         account_map: dict[str, str] = {}  # post_id -> account_name
+        plugin_map = {}  # post_id -> plugin (for Signal 2 checks)
 
         for account_name, posts in all_posts.items():
             platform = manager.get_account_platform(account_name)
+            plugin = manager.get_account(account_name)
             for post in posts:
                 if post.created_at >= start_date:
                     if platform == "mastodon":
@@ -171,6 +173,7 @@ async def find_unsynced_posts(
                     elif platform == "bluesky":
                         bluesky_posts.append(post)
                     account_map[post.id] = account_name
+                    plugin_map[post.id] = plugin
 
         if not mastodon_posts and not bluesky_posts:
             return {
@@ -196,6 +199,30 @@ async def find_unsynced_posts(
         # Build sync summary
         summary = build_sync_summary(mastodon_posts, bluesky_posts, matches)
 
+        # Signal 2: remove posts created via ripplecast from the unsynced lists
+        post_objects = {p.id: p for p in mastodon_posts + bluesky_posts}
+        ripplecast_synced = []
+
+        def _filter_via_ripplecast(post_dicts: list) -> list:
+            remaining = []
+            for post_dict in post_dicts:
+                post_id = post_dict.get("id", "")
+                post = post_objects.get(post_id)
+                plugin = plugin_map.get(post_id)
+                if post and plugin and plugin.is_posted_via_ripplecast(post):
+                    ripplecast_synced.append(
+                        {"post_id": post_id, "platform": post_dict.get("platform"), "match_type": "posted_via_ripplecast"}
+                    )
+                else:
+                    remaining.append(post_dict)
+            return remaining
+
+        summary["mastodon_only"] = _filter_via_ripplecast(summary["mastodon_only"])
+        summary["bluesky_only"] = _filter_via_ripplecast(summary["bluesky_only"])
+        summary["summary"]["mastodon_only_count"] = len(summary["mastodon_only"])
+        summary["summary"]["bluesky_only_count"] = len(summary["bluesky_only"])
+        summary["summary"]["synced_count"] += len(ripplecast_synced)
+
         # Filter by source account if specified
         if source_account:
             source_platform = manager.get_account_platform(source_account)
@@ -220,6 +247,7 @@ async def find_unsynced_posts(
                 "bluesky_only": summary["bluesky_only"],
             },
             "already_synced": summary["synced"],
+            "already_synced_via_ripplecast": ripplecast_synced,
             "summary": summary["summary"],
         }
 
@@ -639,6 +667,7 @@ async def analyze_post_compatibility(
         }
 
 
+
 @mcp.tool()
 async def get_sync_status(
     account: str,
@@ -694,11 +723,22 @@ async def get_sync_status(
                 not_synced_to.append(f"{target_name} (not connected)")
                 continue
 
+            # Signal 2: check ripplecast metadata first (precise, no LLM needed)
+            if source.is_posted_via_ripplecast(post):
+                synced_to.append(
+                    {
+                        "account": target_name,
+                        "platform": target_platform,
+                        "match_type": "posted_via_ripplecast",
+                    }
+                )
+                continue
+
             if not ctx:
                 not_synced_to.append(f"{target_name} (context required for matching)")
                 continue
 
-            # Get recent posts from target account
+            # Signal 1: fall back to LLM content matching
             target_posts = await manager.get_posts(
                 target_name,
                 limit=50,
@@ -706,7 +746,6 @@ async def get_sync_status(
                 exclude_reposts=True,
             )
 
-            # Use LLM to find matches
             matches = await match_posts_with_llm(
                 [post],
                 target_posts,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,8 +1,11 @@
 """Tests for the MCP server tools."""
 
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
+from ripplecast.models import Post, PostMatch
 
 
 class TestServerTools:
@@ -215,3 +218,310 @@ class TestServerTools:
             assert result["dry_run"] is True
             assert result["total"] == 1
             assert result["results"][0]["status"] == "would_succeed"
+
+
+class TestGetSyncStatus:
+    """Tests for get_sync_status tool — Signal 1 and Signal 2."""
+
+    def _make_manager(self, source_post, target_posts, matches, via_ripplecast=False):
+        """Build a mock platform manager for get_sync_status tests."""
+        mock_source = MagicMock()
+        mock_source.connected = True
+        mock_source.get_post_by_id = AsyncMock(return_value=source_post)
+        mock_source.is_posted_via_ripplecast = MagicMock(return_value=via_ripplecast)
+
+        mock_target = MagicMock()
+        mock_target.connected = True
+
+        mock_manager = MagicMock()
+        mock_manager.get_account.side_effect = lambda a: (
+            mock_source if a == "test-mastodon" else mock_target
+        )
+        mock_manager.get_account_platform.side_effect = lambda a: (
+            "mastodon" if a == "test-mastodon" else "bluesky"
+        )
+        mock_manager.get_all_accounts.return_value = {
+            "test-mastodon": mock_source,
+            "test-bluesky": mock_target,
+        }
+        mock_manager.get_posts = AsyncMock(return_value=target_posts)
+        return mock_manager
+
+    @pytest.mark.asyncio
+    async def test_signal1_content_match_regardless_of_timestamp_order(self):
+        """Signal 1: content match is found even when target post predates source post."""
+        from ripplecast.server import get_sync_status
+
+        # Bluesky post was published BEFORE the Mastodon post
+        source_post = Post(
+            id="111",
+            platform="mastodon",
+            account="test-mastodon",
+            text="Hello world! Cross-platform post.",
+            created_at=datetime(2025, 2, 13, 10, 0, 0, tzinfo=timezone.utc),
+            url="https://mastodon.social/@testuser/111",
+        )
+        older_bluesky_post = Post(
+            id="at://did:plc:test/app.bsky.feed.post/aaa",
+            platform="bluesky",
+            account="test-bluesky",
+            text="Hello world! Cross-platform post.",
+            created_at=datetime(2025, 2, 1, 10, 0, 0, tzinfo=timezone.utc),  # 12 days earlier
+            url="https://bsky.app/profile/test.bsky.social/post/aaa",
+        )
+
+        mock_manager = self._make_manager(
+            source_post,
+            [older_bluesky_post],
+            matches=[],
+        )
+
+        mock_ctx = MagicMock()
+        expected_match = PostMatch(
+            post_a_id="111",
+            post_b_id="at://did:plc:test/app.bsky.feed.post/aaa",
+            confidence=0.95,
+            reason="identical text",
+        )
+
+        with patch("ripplecast.server.get_platform_manager", return_value=mock_manager), patch(
+            "ripplecast.server.match_posts_with_llm", AsyncMock(return_value=[expected_match])
+        ):
+            result = await get_sync_status(
+                account="test-mastodon",
+                post_id="111",
+                ctx=mock_ctx,
+            )
+
+        assert result["success"] is True
+        assert len(result["synced_to"]) == 1
+        assert result["synced_to"][0]["account"] == "test-bluesky"
+        assert result["synced_to"][0]["post_id"] == "at://did:plc:test/app.bsky.feed.post/aaa"
+        assert result["not_synced_to"] == []
+
+    @pytest.mark.asyncio
+    async def test_signal2_mastodon_application_metadata(self):
+        """Signal 2: Mastodon post with application.name='ripplecast' is considered synced."""
+        from ripplecast.server import get_sync_status
+
+        source_post = Post(
+            id="222",
+            platform="mastodon",
+            account="test-mastodon",
+            text="A post created via ripplecast.",
+            created_at=datetime(2025, 2, 13, 10, 0, 0, tzinfo=timezone.utc),
+            url="https://mastodon.social/@testuser/222",
+            raw_data={"application": {"name": "ripplecast", "website": None}},
+        )
+
+        mock_manager = self._make_manager(source_post, [], matches=[], via_ripplecast=True)
+        mock_ctx = MagicMock()
+
+        with patch("ripplecast.server.get_platform_manager", return_value=mock_manager), patch(
+            "ripplecast.server.match_posts_with_llm", AsyncMock(return_value=[])
+        ):
+            result = await get_sync_status(
+                account="test-mastodon",
+                post_id="222",
+                ctx=mock_ctx,
+            )
+
+        assert result["success"] is True
+        assert len(result["synced_to"]) == 1
+        assert result["synced_to"][0]["account"] == "test-bluesky"
+        assert result["synced_to"][0]["match_type"] == "posted_via_ripplecast"
+        assert result["not_synced_to"] == []
+
+    @pytest.mark.asyncio
+    async def test_signal2_bluesky_via_metadata(self):
+        """Signal 2: Bluesky post with raw_data via='ripplecast' is considered synced."""
+        from ripplecast.server import get_sync_status
+
+        source_post = Post(
+            id="at://did:plc:test/app.bsky.feed.post/bbb",
+            platform="bluesky",
+            account="test-bluesky",
+            text="A post created via ripplecast.",
+            created_at=datetime(2025, 2, 13, 10, 0, 0, tzinfo=timezone.utc),
+            url="https://bsky.app/profile/test.bsky.social/post/bbb",
+            raw_data={"uri": "at://did:plc:test/app.bsky.feed.post/bbb", "cid": "abc", "via": "ripplecast"},
+        )
+
+        mock_source = MagicMock()
+        mock_source.connected = True
+        mock_source.get_post_by_id = AsyncMock(return_value=source_post)
+
+        mock_target = MagicMock()
+        mock_target.connected = True
+
+        mock_manager = MagicMock()
+        mock_manager.get_account.side_effect = lambda a: (
+            mock_target if a == "test-mastodon" else mock_source
+        )
+        mock_manager.get_account_platform.side_effect = lambda a: (
+            "mastodon" if a == "test-mastodon" else "bluesky"
+        )
+        mock_manager.get_all_accounts.return_value = {
+            "test-mastodon": mock_target,
+            "test-bluesky": mock_source,
+        }
+        mock_manager.get_posts = AsyncMock(return_value=[])
+
+        mock_ctx = MagicMock()
+
+        with patch("ripplecast.server.get_platform_manager", return_value=mock_manager), patch(
+            "ripplecast.server.match_posts_with_llm", AsyncMock(return_value=[])
+        ):
+            result = await get_sync_status(
+                account="test-bluesky",
+                post_id="at://did:plc:test/app.bsky.feed.post/bbb",
+                ctx=mock_ctx,
+            )
+
+        assert result["success"] is True
+        assert len(result["synced_to"]) == 1
+        assert result["synced_to"][0]["account"] == "test-mastodon"
+        assert result["synced_to"][0]["match_type"] == "posted_via_ripplecast"
+        assert result["not_synced_to"] == []
+
+    @pytest.mark.asyncio
+    async def test_no_match_and_no_ripplecast_signal_is_unsynced(self):
+        """A post with no content match and no ripplecast signal remains unsynced."""
+        from ripplecast.server import get_sync_status
+
+        source_post = Post(
+            id="333",
+            platform="mastodon",
+            account="test-mastodon",
+            text="Only on Mastodon, not synced anywhere.",
+            created_at=datetime(2025, 2, 13, 10, 0, 0, tzinfo=timezone.utc),
+            url="https://mastodon.social/@testuser/333",
+        )
+
+        mock_manager = self._make_manager(source_post, [], matches=[])
+        mock_ctx = MagicMock()
+
+        with patch("ripplecast.server.get_platform_manager", return_value=mock_manager), patch(
+            "ripplecast.server.match_posts_with_llm", AsyncMock(return_value=[])
+        ):
+            result = await get_sync_status(
+                account="test-mastodon",
+                post_id="333",
+                ctx=mock_ctx,
+            )
+
+        assert result["success"] is True
+        assert result["synced_to"] == []
+        assert "test-bluesky" in result["not_synced_to"]
+
+
+class TestFindUnsyncedPosts:
+    """Tests for find_unsynced_posts tool — Signal 2 filtering."""
+
+    @pytest.mark.asyncio
+    async def test_signal2_removes_ripplecast_posts_from_unsynced(self):
+        """Posts created via ripplecast are not reported as unsynced."""
+        from ripplecast.server import find_unsynced_posts
+
+        mastodon_post = Post(
+            id="111",
+            platform="mastodon",
+            account="test-mastodon",
+            text="A post created via ripplecast.",
+            created_at=datetime(2026, 2, 17, 10, 0, 0, tzinfo=timezone.utc),
+            url="https://mastodon.social/@testuser/111",
+            raw_data={"application": {"name": "ripplecast"}},
+        )
+
+        mock_mastodon_plugin = MagicMock()
+        mock_mastodon_plugin.connected = True
+        mock_mastodon_plugin.is_posted_via_ripplecast = MagicMock(return_value=True)
+
+        mock_bluesky_plugin = MagicMock()
+        mock_bluesky_plugin.connected = True
+        mock_bluesky_plugin.is_posted_via_ripplecast = MagicMock(return_value=False)
+
+        mock_manager = MagicMock()
+        mock_manager.get_account_platform.side_effect = lambda a: (
+            "mastodon" if a == "test-mastodon" else "bluesky"
+        )
+        mock_manager.get_account.side_effect = lambda a: (
+            mock_mastodon_plugin if a == "test-mastodon" else mock_bluesky_plugin
+        )
+        mock_manager.get_all_posts = AsyncMock(
+            return_value={
+                "test-mastodon": [mastodon_post],
+                "test-bluesky": [],
+            }
+        )
+
+        mock_ctx = MagicMock()
+
+        with patch("ripplecast.server.get_platform_manager", return_value=mock_manager), patch(
+            "ripplecast.server.match_posts_with_llm", AsyncMock(return_value=[])
+        ):
+            result = await find_unsynced_posts(ctx=mock_ctx, days_back=30)
+
+        assert result["success"] is True
+        assert result["unsynced"]["mastodon_only"] == []
+        assert len(result["already_synced_via_ripplecast"]) == 1
+        assert result["already_synced_via_ripplecast"][0]["post_id"] == "111"
+        assert result["already_synced_via_ripplecast"][0]["match_type"] == "posted_via_ripplecast"
+
+
+class TestIsPostedViaRipplecast:
+    """Unit tests for is_posted_via_ripplecast on each platform plugin."""
+
+    def _mastodon_post(self, raw_data=None):
+        from ripplecast.config import MastodonConfig
+        from ripplecast.platforms.mastodon import MastodonPlugin
+
+        plugin = MastodonPlugin(MastodonConfig(instance_url="https://mastodon.social", access_token="tok"))
+        post = Post(
+            id="x",
+            platform="mastodon",
+            text="test",
+            created_at=datetime(2025, 1, 1, tzinfo=timezone.utc),
+            url="https://mastodon.social/x",
+            raw_data=raw_data or {},
+        )
+        return plugin, post
+
+    def _bluesky_post(self, raw_data=None):
+        from ripplecast.config import BlueskyConfig
+        from ripplecast.platforms.bluesky import BlueskyPlugin
+
+        plugin = BlueskyPlugin(BlueskyConfig(handle="test.bsky.social", app_password="xxxx"))
+        post = Post(
+            id="at://did:plc:test/app.bsky.feed.post/x",
+            platform="bluesky",
+            text="test",
+            created_at=datetime(2025, 1, 1, tzinfo=timezone.utc),
+            url="https://bsky.app/profile/test.bsky.social/post/x",
+            raw_data=raw_data or {},
+        )
+        return plugin, post
+
+    def test_mastodon_application_name_ripplecast(self):
+        plugin, post = self._mastodon_post({"application": {"name": "ripplecast"}})
+        assert plugin.is_posted_via_ripplecast(post) is True
+
+    def test_mastodon_application_name_case_insensitive(self):
+        plugin, post = self._mastodon_post({"application": {"name": "Ripplecast"}})
+        assert plugin.is_posted_via_ripplecast(post) is True
+
+    def test_mastodon_application_name_other_app(self):
+        plugin, post = self._mastodon_post({"application": {"name": "Toot!"}})
+        assert plugin.is_posted_via_ripplecast(post) is False
+
+    def test_mastodon_no_application_field(self):
+        plugin, post = self._mastodon_post({})
+        assert plugin.is_posted_via_ripplecast(post) is False
+
+    def test_bluesky_via_field_ripplecast(self):
+        plugin, post = self._bluesky_post({"uri": "at://...", "cid": "abc", "via": "ripplecast"})
+        assert plugin.is_posted_via_ripplecast(post) is True
+
+    def test_bluesky_no_via_field(self):
+        plugin, post = self._bluesky_post({"uri": "at://...", "cid": "abc"})
+        assert plugin.is_posted_via_ripplecast(post) is False


### PR DESCRIPTION
## Summary

Fixes #9. Improves `get_sync_status` and `find_unsynced_posts` to use two signals for accurate sync detection:

- **Signal 1 — Bidirectional content match**: Removes the timestamp ordering constraint from the LLM matching prompt, so a post is considered synced regardless of which platform it appeared on first.
- **Signal 2 — Ripplecast attribution**: Adds `is_posted_via_ripplecast()` to `PlatformPlugin`. Mastodon checks `application.name`; Bluesky checks a `via` field written into the AT Protocol record at post creation time. Posts with this signal are marked synced without an LLM call.

`find_unsynced_posts` now also returns an `already_synced_via_ripplecast` list so the caller can see which posts were filtered via Signal 2.

## Claude Code Notes
- The code was not object-oriented.  With just 2 cases, bluesky and mastodon, maybe it is overkill.  But with some prompting, Claude Code actually generated decent code and the result was much cleaner.  So I kind of wonder why Claude Code wouldn't just do it?
- The code also was not hooked up correctly, such that it had a bug in checking the sync status based on the metadata.  I used Claude Desktop to run the tests, asked Claude Desktop to produce a bug report for Claude Code, fed that report to Claude Code, and it fixed the bug.
- I also prompt Claude Code to do the metadata check first since that is more precise, before doing the text matching check.  I guess Claude Code does not consider performance difference like that.  But on that note, I didn't realize that MCP server can invoke LLM while executing.  I read the code and thought that was pretty cool, and "it will take me a while to figure out how to do that correctly!".  
- I prompted for another enhancement but changed my mind and stopped the Claude Code execution.  That appeared to have messed up the chat history.  So I was not abel to review the chat history and record my learning of Claude Code.  The above are based on the memory
- Also when editing the commit comment, if I accidentally messed up the formatting and causing the commit to fail, I lose all the edits.  I have to say that is pretty frustrating.